### PR TITLE
Apparently missing this:

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 elasticsearch8==8.3.3
 voluptuous>=0.13.1
+pyyaml==6.0.0


### PR DESCRIPTION
```
WARNING: autodoc: failed to import class 'Builder' from module 'es_client'; the following exception was raised:
No module named 'yaml'
```