### PR TITLE
Added pint module to docs/requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 elasticsearch8==8.3.3
 voluptuous>=0.13.1
 pyyaml==6.0.0
+pint>=0.19.2


### PR DESCRIPTION
To fix multiple messages in readthedocs.io of the format:

```
WARNING: autodoc: failed to import class 'XXXXXX' from module 'xxxxxx'; the following exception was raised:
No module named 'pint'
```