### PR TITLE
Release prep for v8.11.0

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,16 @@
 Changelog
 =========
 
+8.11.0 (15 November 2023)
+-------------------------
+
+**Changes**
+
+  * Dependency version bumps in this version:
+      * ``elasticsearch8==8.11.0``
+  * Replace ``Mock`` with ``unittest.Mock`` in unit tests.
+  * Add Python 3.12 as a supported version (tested).
+
 8.10.3 (2 October 2023)
 -----------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 intersphinx_mapping = {
 	'python': ('https://docs.python.org/3.11', None),
-	'elasticsearch8': ('https://elasticsearch-py.readthedocs.io/en/v8.10.0', None),
+	'elasticsearch8': ('https://elasticsearch-py.readthedocs.io/en/v8.11.0', None),
     'elastic-transport': ('https://elastic-transport-python.readthedocs.io/en/stable', None),
     'voluptuous': ('http://alecthomas.github.io/voluptuous/docs/_build/html', None),
     'click': ('https://click.palletsprojects.com/en/8.1.x', None),

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-elasticsearch8==8.10.0
+elasticsearch8==8.11.0
 voluptuous>=0.13.1
 pyyaml==6.0.1
 pint>=0.19.2

--- a/es_client/version.py
+++ b/es_client/version.py
@@ -1,2 +1,2 @@
 """Release version"""
-__version__ = '8.10.3'
+__version__ = '8.11.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 keywords = [
     "elasticsearch",
@@ -26,7 +27,7 @@ keywords = [
     "command-line"
 ]
 dependencies = [
-    "elasticsearch8==8.10.0",
+    "elasticsearch8==8.11.0",
     "click==8.1.7",
     "pyyaml==6.0.1",
     "voluptuous>=0.13.1",
@@ -39,7 +40,7 @@ test = [
     "requests",
     "pytest >=7.2.1",
     "pytest-cov",
-    "mock",
+    "unittest",
 ]
 doc = ["sphinx", "sphinx_rtd_theme"]
 

--- a/tests/unit/test_helpers_utils.py
+++ b/tests/unit/test_helpers_utils.py
@@ -6,8 +6,8 @@ import random
 import string
 import binascii
 from unittest import TestCase
+from unittest.mock import Mock
 import pytest
-from mock import Mock
 from es_client.exceptions import ConfigurationError
 from es_client.helpers.utils import (
     ensure_list, get_yaml, prune_nones, read_file, verify_ssl_paths, verify_url_schema,


### PR DESCRIPTION
**Changes**

  * Dependency version bumps in this version:
      * ``elasticsearch8==8.11.0``
  * Replace ``Mock`` with ``unittest.Mock`` in unit tests.
  * Add Python 3.12 as a supported version (tested).