### PR TITLE
Fix for filter schema

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,17 @@
 Changelog
 =========
 
+8.12.2 (31 January 2024)
+------------------------
+
+**Fixes**
+
+In trying to make ``SchemaCheck`` reusable, I discovered that it _always_,
+was unconditionally attempting apply the ``password_filter`` on every
+``config`` coming through. An empty filter shows up as ``None``, causing
+an AttributeError exception. Going to only do ``password_filter`` when
+``config`` is a ``dict``.
+
 8.12.1 (31 January 2024)
 ------------------------
 

--- a/es_client/helpers/schemacheck.py
+++ b/es_client/helpers/schemacheck.py
@@ -50,7 +50,10 @@ class SchemaCheck(object):
         self.logger = logging.getLogger(__name__)
         # Set the Schema for validation...
         self.logger.debug('Schema: %s', schema)
-        self.logger.debug('"%s" config: %s', test_what, password_filter(config))
+        if isinstance(config, dict):
+            self.logger.debug('"%s" config: %s', test_what, password_filter(config))
+        else:
+            self.logger.debug('"%s" config: %s', test_what, config)
         self.config = config
         self.schema = schema
         self.test_what = test_what

--- a/es_client/version.py
+++ b/es_client/version.py
@@ -1,2 +1,2 @@
 """Release version"""
-__version__ = '8.12.1'
+__version__ = '8.12.2'

--- a/tests/unit/test_helpers_schemacheck.py
+++ b/tests/unit/test_helpers_schemacheck.py
@@ -2,6 +2,7 @@
 # pylint: disable=protected-access, import-error
 # add import-error here ^^^ to avoid false-positives for the local import
 from unittest import TestCase
+from voluptuous import Schema
 from es_client.exceptions import ConfigurationError
 from es_client.helpers.schemacheck import SchemaCheck
 from es_client.defaults import config_schema, VERSION_MIN, version_min, VERSION_MAX, version_max
@@ -40,6 +41,16 @@ class TestSchemaCheck(TestCase):
             'client'
         )
         self.assertRaises(ConfigurationError, schema.result)
+    def test_does_not_password_filter_non_dict(self):
+        """Ensure that if config is not a dictionary that it doesn't choke"""
+        config = None
+        schema = SchemaCheck(
+            config,
+            Schema(config),
+            'arbitrary',
+            'anylocation'
+        )
+        self.assertIsNone(schema.result(), Schema(None))
 
 class TestVersionMinMax(TestCase):
     """Test version min and max functions"""


### PR DESCRIPTION
I've only needed dict schemas before now, so the password_filter function was a no-brainer.

Turns out I don't need to log None type schema configs.

The fix is to test with isinstance(config, dict) and then only password_filter those.