### PR TITLE
SchemaCheck failures now raise FailedValidation

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,16 @@
 Changelog
 =========
 
+8.12.3 (31 January 2024)
+------------------------
+
+**Change**
+
+Since I'm doing Schema validation here now, I think it appropriate to have a
+dedicated exception for SchemaCheck failures.
+
+This will be FailedValidation.
+
 8.12.2 (31 January 2024)
 ------------------------
 

--- a/es_client/exceptions.py
+++ b/es_client/exceptions.py
@@ -23,3 +23,13 @@ class LoggingException(ESClientException):
     """
     Exception raised when logging cannot be configured properly
     """
+
+class SchemaException(ESClientException):
+    """
+    Exception base class for all exceptions related to Schema failure
+    """
+
+class FailedValidation(SchemaException):
+    """
+    Exception raised when SchemaCheck validation fails.
+    """

--- a/es_client/helpers/schemacheck.py
+++ b/es_client/helpers/schemacheck.py
@@ -4,7 +4,7 @@ import logging
 from re import sub
 from copy import deepcopy
 from es_client.defaults import KEYS_TO_REDACT
-from es_client.exceptions import ConfigurationError
+from es_client.exceptions import FailedValidation
 
 def password_filter(data: dict) -> dict:
     """
@@ -87,7 +87,7 @@ class SchemaCheck(object):
     def result(self):
         """
         Return the result of the Schema test, if successful.
-        Otherwise, raise a :class:`ConfigurationError <es_client.exceptions.ConfigurationError>`
+        Otherwise, raise a :class:`FailedValidation <es_client.exceptions.FailedValidation>`
         """
         try:
             return self.schema(self.config)
@@ -100,7 +100,7 @@ class SchemaCheck(object):
                 self.error = f'{exc}'
             self.__parse_error()
             self.logger.error('Schema error: %s', self.error)
-            raise ConfigurationError(
+            raise FailedValidation(
                 f'Configuration: {self.test_what}: Location: {self.location}: '
                 f'Bad Value: "{self.badvalue}", {self.error}. Check configuration file.'
             ) from exc

--- a/es_client/version.py
+++ b/es_client/version.py
@@ -1,2 +1,2 @@
 """Release version"""
-__version__ = '8.12.2'
+__version__ = '8.12.3'

--- a/tests/unit/test_helpers_schemacheck.py
+++ b/tests/unit/test_helpers_schemacheck.py
@@ -3,14 +3,14 @@
 # add import-error here ^^^ to avoid false-positives for the local import
 from unittest import TestCase
 from voluptuous import Schema
-from es_client.exceptions import ConfigurationError
+from es_client.exceptions import FailedValidation
 from es_client.helpers.schemacheck import SchemaCheck
 from es_client.defaults import config_schema, VERSION_MIN, version_min, VERSION_MAX, version_max
 
 class TestSchemaCheck(TestCase):
     """Test SchemaCheck class and member functions"""
     def test_bad_port_value(self):
-        """Ensure that a bad port value Raises a ConfigurationError"""
+        """Ensure that a bad port value Raises a FailedValidation"""
         config = {
             'elasticsearch': {
                 'client': {
@@ -24,9 +24,9 @@ class TestSchemaCheck(TestCase):
             'elasticsearch',
             'client'
         )
-        self.assertRaises(ConfigurationError, schema.result)
+        self.assertRaises(FailedValidation, schema.result)
     def test_entirely_wrong_keys(self):
-        """Ensure that unacceptable keys Raises a ConfigurationError"""
+        """Ensure that unacceptable keys Raises a FailedValidation"""
         config = {
             'elasticsearch': {
                 'client_not': {},
@@ -40,7 +40,7 @@ class TestSchemaCheck(TestCase):
             'elasticsearch',
             'client'
         )
-        self.assertRaises(ConfigurationError, schema.result)
+        self.assertRaises(FailedValidation, schema.result)
     def test_does_not_password_filter_non_dict(self):
         """Ensure that if config is not a dictionary that it doesn't choke"""
         config = None


### PR DESCRIPTION
This is to keep similar named exceptions from colliding in apps using es_client