### PR TITLE
Move the try/except block for Docker logging

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,16 @@
 Changelog
 =========
 
+8.12.4 (1 February 2024)
+------------------------
+
+**Fixes**
+
+The try/except block for Docker logging needed to be out one level farther.
+
+This should fix the permissions error issues at last.
+
+
 8.12.3 (31 January 2024)
 ------------------------
 

--- a/es_client/helpers/logging.py
+++ b/es_client/helpers/logging.py
@@ -53,15 +53,15 @@ class LogInfo:
             # We only do this if we detect Docker
             fpath = '/proc/1/fd/1'
             permission = False
-            with open(fpath, 'wb+', buffering=0) as fhdl:
-                try:
+            try:
+                with open(fpath, 'wb+', buffering=0) as fhdl:
                     # And we've verified that the path is a tty
                     if fhdl.isatty():
                         # And verified that we have write permissions to that path
-                        fhdl.write(f'Permission to write to {fpath}?\n'.encode())
+                        fhdl.write('...\n'.encode())
                         permission = True
-                except PermissionError:
-                    clicho(f'Docker container does not appear to have a writable tty at {fpath}.')
+            except PermissionError:
+                clicho(f'Docker container does not appear to have a writable tty at {fpath}.')
             if permission:
                 self.handler = logging.FileHandler(fpath)
         else:

--- a/es_client/helpers/schemacheck.py
+++ b/es_client/helpers/schemacheck.py
@@ -28,7 +28,7 @@ def password_filter(data: dict) -> dict:
         return mydict
     return iterdict(deepcopy(data))
 
-class SchemaCheck(object):
+class SchemaCheck:
     """
     Validate ``config`` with the provided :py:class:`~.voluptuous.schema_builder.Schema`.
     ``test_what`` and ``location`` are for reporting the results, in case of
@@ -61,7 +61,7 @@ class SchemaCheck(object):
         self.badvalue = 'no bad value yet'
         self.error = 'No error yet'
 
-    def __parse_error(self):
+    def parse_error(self):
         """
         Report the error, and try to report the bad key or value as well.
         """
@@ -98,7 +98,7 @@ class SchemaCheck(object):
             except Exception as err:
                 self.logger.error('Could not parse exception: %s', err)
                 self.error = f'{exc}'
-            self.__parse_error()
+            self.parse_error()
             self.logger.error('Schema error: %s', self.error)
             raise FailedValidation(
                 f'Configuration: {self.test_what}: Location: {self.location}: '

--- a/es_client/version.py
+++ b/es_client/version.py
@@ -1,2 +1,2 @@
 """Release version"""
-__version__ = '8.12.3'
+__version__ = '8.12.4'


### PR DESCRIPTION
It needs to be out one more level in order to catch the file permissions check. It turned out to be a faulty expectation that it would not test for write permissions until it actually attempted to write, instead of immediately upon calling, `with open(fpath, 'wb+', ...)`

Additional change is cosmetic Pylint stuff.

All tests pass.