### PR TITLE
Release 8.12.6 ready

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,12 +3,36 @@
 Changelog
 =========
 
-8.12.6 (? ? ?)
---------------
+8.12.6 (20 March 2024)
+----------------------
 
 **Changes**
 
   * After reading and re-reading through the tutorial, I made a few doc changes.
+  * ``ctx.obj`` is instantiated in ``helpers.config.context_settings`` now, saving yet another
+    line of code from being needed in a functional command-line script.
+  * Decided it was actually time to programmatically approach the huge list of decorators necessary
+    to make ``es_client`` work in the example. Now there's a single decorator,
+    ``@options_from_dict()`` in ``helpers.config``, and it takes a dictionary as an argument. The
+    form of this dictionary should be:
+
+    .. code-block:: python
+
+      {
+        "option1": {"onoff": {}, "override": {}, "settings": {}},
+        "option2": {"onoff": {}, "override": {}, "settings": {}},
+        # ...
+        "optionN": {"onoff": {}, "override": {}, "settings": {}},
+      }
+    
+    The defaults are provided in ``helpers.defaults`` as constants ``OPTION_DEFAULTS`` and
+    ``SHOW_EVERYTHING``. These can be overridden programmatically or very tediously manually.
+  * Dependency version bumps:
+
+    .. code-block:: python
+
+      elasticsearch8==8.12.1
+      certifi==2024.2.2
 
 8.12.5 (4 February 2024)
 ------------------------

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1,0 +1,229 @@
+.. _tutorial2:
+
+####################
+Tutorial 2: Advanced
+####################
+
+**********************
+It's the little things
+**********************
+
+If you haven't gone through the regular :ref:`tutorial` yet, you should definitely look there first.
+
+The following are little things that will help with making that app more complete.
+
+.. _setting_version:
+
+*******************************
+Setting the application version
+*******************************
+
+You probably noticed that there's a version output flag in the help/usage output:
+
+.. code-block:: console
+
+   -v, --version                   Show the version and exit.
+
+If you leave this as-is, it will only ever show the version of ``es_client``, so let's see how to
+change this to be our own version.
+
+===================
+Where's my version?
+===================
+
+Most PEP compliant releases of a project will have a ``__version__`` defined somewhere. By default,
+Click will attempt to guess the version from that value. It does so successfully with ``es_client``
+in our example script.
+
+.. code-block:: python
+
+   @click.version_option(None, '-v', '--version', prog_name="cli_example")
+
+If Click guesses wrong, you can try to tell it which package to check:
+
+.. code-block:: python
+
+   @click.version_option(None, '-v', '--version', pacakge_name='es_client', prog_name="cli_example")
+
+And if that still doesn't work, you can manually specify a version:
+
+.. code-block:: python
+
+   @click.version_option('X.Y.Z', '-v', '--version', prog_name="cli_example")
+
+or directly reference your ``__version__``:
+
+.. code-block:: python
+
+   from es_client import __version__
+   # ...
+   @click.version_option(__version__, '-v', '--version', prog_name="cli_example")
+
+With regard to ``prog_name``, the documentation says, "The name of the CLI to show in the message. If
+not provided, it will be detected from the command."
+
+If I leave ``prog_name`` unset and run the version output, I would see:
+
+.. code-block:: console
+
+   run_script.py, version X.Y.Z
+
+But with it set, I see:
+
+.. code-block:: console
+
+   cli_example, version X.Y.Z
+
+But you can also format the output of this using ``message``. According to the documentation, "The
+message to show. The values ``%(prog)s``, ``%(package)s``, and ``%(version)s`` are available.
+Defaults to ``"%(prog)s, version %(version)s"``."
+
+So if I set:
+
+.. code-block:: python
+
+   @click.version_option(
+      None, '-v', '--version', prog_name="cli_example",
+      message='%(prog)s from %(package)s, version %(version)s')
+
+I would see:
+
+.. code-block:: console
+
+   python run_script.py -v                                                                                                  ─╯
+   cli_example from es_client, version X.Y.Z
+
+.. _importing:
+
+*****************************************
+Importing es_client into your own project
+*****************************************
+
+It's all well and good to test against the es_client code, but wouldn't you rather make use of it
+in your own code?
+
+=================================
+Include es_client as a dependency
+=================================
+
+If you're following PEP conventions, your project probably has a ``pyproject.toml`` file. Inside
+that file will be a header labeled ``[project]``, and under that section will be a subsection
+titled ``dependencies`` followed by a list of modules your project depends on. This is where you
+need to list ``es_client`` as a dependency:
+
+.. code-block:: toml
+
+   dependencies = [
+       ...
+       "es_client==X.Y.Z"
+       ...
+   ]
+
+You will probably need to do something to make sure it's imported into your virtualenv while you are
+coding and testing. Having it installed allows IDEs and similar coding environments to help with
+documentation and code completion. Installing dependencies can be accomplished by running:
+
+.. code-block:: console
+
+   pip install -U .
+
+If run from the root of your project, this will install all dependencies in ``pyproject.toml``.
+
+=====================
+Import into your code
+=====================
+
+Once ``es_client`` is available to your code, you can import it or any of its classes, submodules,
+functions and constants. This pattern is visible in the example script at the top of the page:
+
+.. code-block:: python
+
+   from es_client.helpers.config import (
+      context_settings, generate_configdict, get_client, get_config,
+      options_from_dict)
+   from es_client.defaults import OPTION_DEFAULTS, SHOW_EVERYTHING
+   from es_client.helpers.logging import configure_logging
+
+
+==================
+"Secret Borrowing"
+==================
+
+"Good artists borrow. Great artists steal." (Attributed to Pablo Picasso)
+
+It's completely acceptable and appropriate to copy the :ref:`example script <example_file>` and use
+it as the basis for your own application. Why re-invent the wheel when you have a working wheel that
+you only need to tweak a bit?
+
+-----------------------------
+Add your bits or link to them
+-----------------------------
+
+If your code is ready to go and just needs es_client, then you should know what to do now. First,
+import the dependencies:
+
+.. code-block:: python
+
+   import click
+   from es_client.helpers.config import (
+      context_settings, generate_configdict, get_client, get_config,
+      options_from_dict)
+   from es_client.defaults import OPTION_DEFAULTS, SHOW_EVERYTHING
+   from es_client.helpers.logging import configure_logging
+
+Then, create a Click command that will allow you to collect all of the settings needed to create a
+client connection:
+
+.. code-block:: python
+
+   @click.group(context_settings=context_settings())
+   @options_from_dict(OPTION_DEFAULTS)
+   @click.version_option(None, '-v', '--version', prog_name="cli_example")
+   @click.pass_context
+   def run(ctx, config, hosts, cloud_id, api_token, id, api_key, username, password, bearer_auth,
+       opaque_id, request_timeout, http_compress, verify_certs, ca_certs, client_cert, client_key,
+       ssl_assert_hostname, ssl_assert_fingerprint, ssl_version, master_only, skip_version_test,
+       loglevel, logfile, logformat, blacklist
+   ):
+       """
+       CLI Example 
+       
+       Any text added to a docstring will show up in the --help/usage output.
+   
+       Set short_help='' in @func.command() definitions for each command for terse descriptions in the
+       main help/usage output, as with show_all_options() in this example.
+       """
+       ctx.obj['default_config'] = None
+       get_config(ctx, quiet=False)
+       configure_logging(ctx)
+       generate_configdict(ctx)
+   
+   @run.command()
+   @click.pass_context
+   def my_command(ctx):
+       client = get_client(configdict=ctx.obj['configdict'])
+       # your code goes here
+
+This will follow the pattern where you get the credentials and settings in the root-level command,
+and then tell it you want to run ``my_command`` where a client connection will be established and
+then your code uses it however you like! Note that we use the name of our root-level command as the
+name of the decorator: ``@run.command()``. This guarantees that ``my_command`` will be a
+sub-command of ``run``.
+
+To run this automatically when this file is called, put this at the end of the file:
+
+.. code-block:: python
+
+   if __name__ == '__main__':
+       run()
+
+Calling your script like ``python my_script.py`` will now automatically call your ``run`` function,
+and you're on your way!
+
+.. _more_advanced:
+
+****************
+Watch This Space
+****************
+
+More advanced tutorials will follow!

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -42,35 +42,40 @@ Output
 
 .. code-block:: shell-session
 
-    Usage: run_script.py [OPTIONS] COMMAND [ARGS]...
-
-      CLI Example (anything here will show up in --help)
-
-    Options:
-      --config PATH                   Path to configuration file.
-      --hosts TEXT                    Elasticsearch URL to connect to.
-      --cloud_id TEXT                 Elastic Cloud instance id
-      --api_token TEXT                The base64 encoded API Key token
-      --id TEXT                       API Key "id" value
-      --api_key TEXT                  API Key "api_key" value
-      --username TEXT                 Elasticsearch username
-      --password TEXT                 Elasticsearch password
-      --request_timeout FLOAT         Request timeout in seconds
-      --verify_certs / --no-verify_certs
-                                      Verify SSL/TLS certificate(s)  [default: verify_certs]
-      --ca_certs TEXT                 Path to CA certificate file or directory
-      --client_cert TEXT              Path to client certificate file
-      --client_key TEXT               Path to client key file
-      --loglevel [DEBUG|INFO|WARNING|ERROR|CRITICAL]
-                                      Log level
-      --logfile TEXT                  Log file
-      --logformat [default|json|ecs]  Log output format
-      -v, --version                   Show the version and exit.
-      -h, --help                      Show this message and exit.
-
-    Commands:
-      show-all-options  Show all configuration options
-      test-connection   Test connection to Elasticsearch
+   Usage: run_script.py [OPTIONS] COMMAND [ARGS]...
+   
+     CLI Example
+   
+     Any text added to a docstring will show up in the --help/usage output.
+   
+     Set short_help='' in @func.command() definitions for each command for terse descriptions in the main help/usage output, as
+     with show_all_options() in this example.
+   
+   Options:
+     --config PATH                   Path to configuration file.
+     --hosts TEXT                    Elasticsearch URL to connect to.
+     --cloud_id TEXT                 Elastic Cloud instance id
+     --api_token TEXT                The base64 encoded API Key token
+     --id TEXT                       API Key "id" value
+     --api_key TEXT                  API Key "api_key" value
+     --username TEXT                 Elasticsearch username
+     --password TEXT                 Elasticsearch password
+     --request_timeout FLOAT         Request timeout in seconds
+     --verify_certs / --no-verify_certs
+                                     Verify SSL/TLS certificate(s)  [default: verify_certs]
+     --ca_certs TEXT                 Path to CA certificate file or directory
+     --client_cert TEXT              Path to client certificate file
+     --client_key TEXT               Path to client key file
+     --loglevel [DEBUG|INFO|WARNING|ERROR|CRITICAL]
+                                     Log level
+     --logfile TEXT                  Log file
+     --logformat [default|json|ecs]  Log output format
+     -v, --version                   Show the version and exit.
+     -h, --help                      Show this message and exit.
+   
+   Commands:
+     show-all-options  Show all configuration options
+     test-connection   Test connection to Elasticsearch
 
 Run the Script with a Command
 -----------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -153,6 +153,7 @@ Contents
    api
    example
    tutorial
+   advanced
    defaults
    helpers
    exceptions

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -8,6 +8,9 @@ Tutorial
 Create A Command-Line App
 *************************
 
+If you haven't gone through the :ref:`example` yet, you should do a once-over there before
+proceeding here.
+
 Now that we see the power of the command-line that is ready for the taking, what's the next step?
 How do you make your own app work with ``es_client``?
 
@@ -16,12 +19,13 @@ start there. I've done the ground work so you don't have to.
 
 .. important:: All of these examples assume you have a simple Elasticsearch instance running at
    localhost:9200 that needs no username or password. This can, in fact, be done using the 
-   ``docker_test`` scripts included in the Github repository. Run 
-   ``docker_test/scripts/create.sh 8.12.0`` to create such an image locally (substitute the version
-   of your choice), and ``docker_test/scripts/destroy.sh`` to remove them when you're done. If you
-   do not have Docker, or choose to use a different cluster, you're responsible for adding whatever
-   configuration options/flags are needed to connect. And I am not at all responsible if you delete
-   an index in production because you did something you shouldn't have.
+   ``docker_test`` scripts included in the Github repository.
+   
+   Run ``docker_test/scripts/create.sh 8.12.0`` to create such an image locally (substitute the 
+   version of your choice), and ``docker_test/scripts/destroy.sh`` to remove them when you're done.
+   If you do not have Docker, or choose to use a different cluster, you're responsible for adding
+   whatever configuration options/flags are needed to connect. And I am not at all responsible if
+   you delete an index in production because you did something you shouldn't have.
 
 .. _tutorial_step_1:
 

--- a/es_client/defaults.py
+++ b/es_client/defaults.py
@@ -1,5 +1,6 @@
 """Define default values"""
 # pylint: disable=line-too-long
+from copy import deepcopy
 from click import Choice, Path
 from six import string_types
 from voluptuous import All, Any, Boolean, Coerce, Optional, Range, Schema
@@ -77,7 +78,7 @@ CLICK_SETTINGS: list = {
         'help': 'Only run if the single host provided is the elected master',
         'default': False,
         'show_default': True,
-        'hidden': True,
+        'hidden': True
     },
     'skip_version_test': {
         'help': 'Elasticsearch version compatibility check',
@@ -140,6 +141,54 @@ SHOW_OPTION: dict = {'hidden': False}
 
 SHOW_ENVVAR: dict = {'show_envvar': True}
 """Override value to make Click's help output show the associated environment variable"""
+
+OVERRIDE: dict = {**SHOW_OPTION, **SHOW_ENVVAR}
+"""Override value to combine these into a single constant"""
+
+ONOFF: dict = {'on': '', 'off': 'no-'}
+"""Default values for enable/disable click options"""
+
+OPTION_DEFAULTS: dict = {
+    'config':{},
+    'hosts':{},
+    'cloud_id':{},
+    'api_token':{},
+    'id':{},
+    'api_key':{},
+    'username':{},
+    'password':{},
+    'bearer_auth':{},
+    'opaque_id':{},
+    'request_timeout':{},
+    'http_compress':{'onoff':ONOFF},
+    'verify_certs':{'onoff':ONOFF},
+    'ca_certs':{},
+    'client_cert':{},
+    'client_key':{},
+    'ssl_assert_hostname':{},
+    'ssl_assert_fingerprint':{},
+    'ssl_version':{},
+    'master-only':{'onoff':ONOFF},
+    'skip_version_test':{'onoff':ONOFF},
+    'loglevel':{'settings':LOGGING_SETTINGS['loglevel']},
+    'logfile':{'settings':LOGGING_SETTINGS['logfile']},
+    'logformat':{'settings':LOGGING_SETTINGS['logformat']},
+    'blacklist':{'settings':LOGGING_SETTINGS['blacklist']},
+}
+"""Default options for iteratively building Click decorators"""
+
+def all_on():
+    """Return default options with all overrides enabled"""
+    options = deepcopy(OPTION_DEFAULTS)
+    retval = {}
+    # pylint: disable=consider-using-dict-items
+    for option in options:
+        retval[option] = options[option]
+        retval[option]['override'] = OVERRIDE
+    return retval
+
+SHOW_EVERYTHING: dict = all_on()
+"""Return options for iteratively building Click decorators with all overrides on"""
 
 # Logging schema
 def config_logging() -> Schema:

--- a/es_client/version.py
+++ b/es_client/version.py
@@ -1,2 +1,2 @@
 """Release version"""
-__version__ = '8.12.5'
+__version__ = '8.12.6'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,12 @@ keywords = [
     "command-line"
 ]
 dependencies = [
-    "elasticsearch8==8.12.0",
+    "elasticsearch8==8.12.1",
     "ecs-logging==2.1.0",
     "click==8.1.7",
     "pyyaml==6.0.1",
     "voluptuous>=0.14.1",
-    "certifi>=2023.11.17",
-    "six>=1.16.0",
+    "certifi>=2024.2.2"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
**Changes**

  * After reading and re-reading through the tutorial, I made a few doc changes.
  * ``ctx.obj`` is instantiated in ``helpers.config.context_settings`` now, saving yet another
    line of code from being needed in a functional command-line script.
  * Decided it was actually time to programmatically approach the huge list of decorators necessary
    to make ``es_client`` work in the example. Now there's a single decorator,
    ``@options_from_dict()`` in ``helpers.config``, and it takes a dictionary as an argument. The
    form of this dictionary should be:
    ```python
      {
        "option1": {"onoff": {}, "override": {}, "settings": {}},
        "option2": {"onoff": {}, "override": {}, "settings": {}},
        # ...
        "optionN": {"onoff": {}, "override": {}, "settings": {}},
      }
    ```
    The defaults are provided in ``helpers.defaults`` as constants ``OPTION_DEFAULTS`` and ``SHOW_EVERYTHING``. These can be overridden programmatically or very tediously manually.

  * Dependency version bumps:

```python
      elasticsearch8==8.12.1
      certifi==2024.2.2
```