### PR TITLE
Fix command-line overriding issue

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,26 @@
 Changelog
 =========
 
+8.12.9 (26 March 2024)
+----------------------
+
+**Bugfix**
+
+  * Reported in #1708. Default values (rather than None values) were overriding what was in config
+    files. As a result, these default values from command-line settings were overriding important
+    settings which were set properly in the configuration file. Hat tip to @rgaduput for reporting
+    this.
+
+**Changes**
+
+  * Updated cli_example.py to make the ``show_all_options`` sub-command show the proper environment
+    variables. This entailed resetting the context_settings. A note explaining the why is now in
+    the comments above that function.
+  * Updates to reflect the default values in the command-line were made in the tutorial and example
+    documentation pages.
+  * A new documentation page was created specific to environment variables.
+  * Version bump ``voluptuous==0.14.2`` from ``0.14.1``
+
 8.12.8 (20 March 2024)
 ----------------------
 

--- a/docs/envvars.rst
+++ b/docs/envvars.rst
@@ -1,0 +1,246 @@
+.. _envvars:
+
+#####################
+Environment Variables
+#####################
+
+Beginning in version 8.12, es_client allows you to use environment variables to configure settings
+*without* needing to specify a command-line option or a configuration file option.
+
+This should prove exceptionally useful in containerized applications like Kubernetes or Docker.
+
+Usage
+-----
+
+A configuration file example:
+
+.. code-block:: yaml
+
+   elasticsearch:
+     client:
+       hosts: http://127.0.0.1:9200
+     other_settings:
+       username: user
+       password: pass
+
+Which would be run as follows:
+
+.. code-block:: shell
+
+   myapp.py --config /path/to/config.yml
+
+or a command-line example:
+
+.. code-block:: shell
+
+   myapp.py --hosts http://127.0.0.1:9200 --username user --password pass
+
+Can *both* be executed with *no* configuration file and *no* command-line options as follows:
+
+.. code-block:: shell
+   
+   ESCLIENT_HOSTS=http://127.0.0.1:9200 ESCLIENT_USERNAME=user ESCLIENT_PASSWORD=pass myapp.py
+
+In Kubernetes or Docker based applications, these environment variables can be set in advance,
+making the program call exceptionally clean. Of course, you're still welcome to use a configuration
+file, but identify it with an environment variable:
+
+.. code-block:: shell
+   
+   ESCLIENT_CONFIG=/path/to/config.yml myapp.py
+
+
+List of Environment Variables
+-----------------------------
+
+.. list-table:: Commonly Used Environment Variables
+   :widths: 33 33 34
+   :header-rows: 1
+
+   * - Configuration File
+     - Command-Line
+     - Environment Variable
+   * - 
+     - ``--config``
+     - ESCLIENT_CONFIG
+   * - hosts
+     - ``--hosts``
+     - :ref:`ESCLIENT_HOSTS <envvars_multiple>`
+   * - cloud_id
+     - ``--cloud_id``
+     - ESCLIENT_CLOUD_ID
+   * - token
+     - ``--api_token``
+     - ESCLIENT_API_TOKEN
+   * - id
+     - ``--id``
+     - ESCLIENT_ID
+   * - api_key
+     - ``--api_key``
+     - ESCLIENT_API_KEY
+   * - username
+     - ``--username``
+     - ESCLIENT_USERNAME
+   * - password
+     - ``--password``
+     - ESCLIENT_PASSWORD
+   * - request_timeout
+     - ``--request_timeout``
+     - ESCLIENT_REQUEST_TIMEOUT
+   * - verify_certs
+     - ``--verify_certs``
+     - :ref:`ESCLIENT_VERIFY_CERTS <envvars_bool>`
+   * - ca_certs
+     - ``--ca_certs``
+     - ESCLIENT_CA_CERTS
+   * - client_cert
+     - ``--client_cert``
+     - ESCLIENT_CLIENT_CERT
+   * - client_key
+     - ``--client_key``
+     - ESCLIENT_CLIENT_KEY
+   * - loglevel
+     - ``--loglevel``
+     - ESCLIENT_LOGLEVEL
+   * - logfile
+     - ``--logfile``
+     - ESCLIENT_LOGFILE
+   * - logformat
+     - ``--logformat``
+     - ESCLIENT_LOGFORMAT
+
+.. list-table:: Uncommon Environment Variables
+   :widths: 33 33 34
+   :header-rows: 1
+
+   * - Configuration File
+     - Command-Line
+     - Environment Variable
+   * - blacklist
+     - ``--blacklist``
+     - :ref:`ESCLIENT_BLACKLIST <envvars_multiple>`
+   * - master_only
+     - ``--master-only``
+     - :ref:`ESCLIENT_MASTER_ONLY <envvars_bool>`
+   * - skip_version_test
+     - ``--skip_version_test``
+     - :ref:`ESCLIENT_SKIP_VERSION_TEST <envvars_bool>`
+   * - bearer_auth
+     - ``--bearer_auth``
+     - ESCLIENT_BEARER_AUTH
+   * - opaque_id
+     - ``--opaque_id``
+     - ESCLIENT_OPAQUE_ID
+   * - http_compress
+     - ``--http_compress``
+     - :ref:`ESCLIENT_HTTP_COMPRESS <envvars_bool>`
+   * - ssl_version
+     - ``--ssl_version``
+     - ESCLIENT_SSL_VERSION
+   * - ssl_assert_hostname
+     - ``--ssl_assert_hostname``
+     - ESCLIENT_SSL_ASSERT_HOSTNAME
+   * - ssl_assert_fingerprint
+     - ``--ssl_assert_fingerprint``
+     - ESCLIENT_SSL_ASSERT_FINGERPRINT
+
+.. _envvars_multiple:
+
+Settings With Multiple Values
+-----------------------------
+
+.. list-table:: Settings With Multiple Values
+   :widths: 33 33 34
+   :header-rows: 1
+
+   * - Configuration File
+     - Command-Line
+     - Environment Variable
+   * - hosts
+     - ``--hosts``
+     - ESCLIENT_HOSTS
+   * - blacklist
+     - ``--blacklist``
+     - ESCLIENT_BLACKLIST
+
+Where multiple values are permitted, as with the ``hosts`` and ``blacklist`` settings, this is done
+by simply specifying multiple values within quotes, e.g.
+
+.. code-block:: shell
+   
+   ESCLIENT_HOSTS="http://127.0.0.1:9200 http://localhost:9200"
+
+This will automatically expand into an array of values:
+
+.. code-block:: shell
+   
+   config: {'client': {'hosts': ['http://127.0.0.1:9200', 'http://localhost:9200']}}...
+
+.. _envvars_bool:
+
+Settings With Boolean Values
+----------------------------
+
+.. list-table:: Settings With Boolean Values
+   :widths: 33 33 34
+   :header-rows: 1
+
+   * - Configuration File
+     - Command-Line
+     - Environment Variable
+   * - verify_certs
+     - ``--verify_certs``
+     - ESCLIENT_VERIFY_CERTS
+   * - master_only
+     - ``--master-only``
+     - ESCLIENT_MASTER_ONLY
+   * - skip_version_test
+     - ``--skip_version_test``
+     - ESCLIENT_SKIP_VERSION_TEST
+   * - http_compress
+     - ``--http_compress``
+     - ESCLIENT_HTTP_COMPRESS
+    
+Where boolean values are accepted, as with the verify_certs setting, this is done with any
+acceptable boolean-eque value, e.g. 0, F, False for false values, or 1, T, True for true values:
+
+.. code-block:: shell
+   
+   ESCLIENT_MASTER_ONLY=true
+   ESCLIENT_MASTER_ONLY=T
+   ESCLIENT_MASTER_ONLY=1
+
+Results in:
+
+.. code-block:: shell
+   
+   'other_settings': {'master_only': True,...
+
+While:
+
+.. code-block:: shell
+   
+   ESCLIENT_MASTER_ONLY=false
+   ESCLIENT_MASTER_ONLY=F
+   ESCLIENT_MASTER_ONLY=0
+
+Results in:
+
+.. code-block:: shell
+   
+   'other_settings': {'master_only': False,...
+
+**NOTE: All string-based booleans are case-insensitive.**
+
+.. list-table:: Acceptable Boolean Values
+   :widths: 50 50
+   :header-rows: 1
+
+   * - True
+     - False
+   * - 1
+     - 0
+   * - True, TRUE, true
+     - False, FALSE, false
+   * - T, t
+     - F, f

--- a/docs/example.rst
+++ b/docs/example.rst
@@ -96,7 +96,7 @@ Output
 .. code-block:: shell-session
 
    Usage: run_script.py show-all-options [OPTIONS]
-
+   
      ALL OPTIONS SHOWN
    
      The full list of options available for configuring a connection at the command-line.
@@ -114,9 +114,9 @@ Output
      --opaque_id TEXT                X-Opaque-Id HTTP header value  [env var: ESCLIENT_OPAQUE_ID]
      --request_timeout FLOAT         Request timeout in seconds  [env var: ESCLIENT_REQUEST_TIMEOUT]
      --http_compress / --no-http_compress
-                                     Enable HTTP compression  [env var: ESCLIENT_HTTP_COMPRESS; default: no-http_compress]
+                                     Enable HTTP compression  [env var: ESCLIENT_HTTP_COMPRESS]
      --verify_certs / --no-verify_certs
-                                     Verify SSL/TLS certificate(s)  [default: verify_certs]
+                                     Verify SSL/TLS certificate(s)  [env var: ESCLIENT_VERIFY_CERTS]
      --ca_certs TEXT                 Path to CA certificate file or directory  [env var: ESCLIENT_CA_CERTS]
      --client_cert TEXT              Path to client certificate file  [env var: ESCLIENT_CLIENT_CERT]
      --client_key TEXT               Path to client key file  [env var: ESCLIENT_CLIENT_KEY]
@@ -127,11 +127,9 @@ Output
                                      ESCLIENT_SSL_ASSERT_FINGERPRINT]
      --ssl_version TEXT              Minimum acceptable TLS/SSL version  [env var: ESCLIENT_SSL_VERSION]
      --master-only / --no-master-only
-                                     Only run if the single host provided is the elected master  [env var: ESCLIENT_MASTER_ONLY;
-                                     default: no-master-only]
+                                     Only run if the single host provided is the elected master  [env var: ESCLIENT_MASTER_ONLY]
      --skip_version_test / --no-skip_version_test
-                                     Elasticsearch version compatibility check  [env var: ESCLIENT_SKIP_VERSION_TEST; default:
-                                     no-skip_version_test]
+                                     Elasticsearch version compatibility check  [env var: ESCLIENT_SKIP_VERSION_TEST]
      --loglevel [DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                      Log level  [env var: ESCLIENT_LOGLEVEL]
      --logfile TEXT                  Log file  [env var: ESCLIENT_LOGFILE]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -154,6 +154,7 @@ Contents
    example
    tutorial
    advanced
+   envvars
    defaults
    helpers
    exceptions

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 elasticsearch8==8.12.1
-voluptuous>=0.14.1
+voluptuous>=0.14.2
 pyyaml==6.0.1
 pint>=0.19.2

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -45,7 +45,7 @@ A look at the code shows us where that name came from:
 
 .. code-block:: python
 
-   @run.command(context_settings=context_settings())
+   @run.command()
    @click.pass_context
    def test_connection(ctx):
        """
@@ -71,7 +71,7 @@ So let's copy the entire ``test_connection`` function and make a few changes:
 
 .. code-block:: python
 
-   @run.command(context_settings=context_settings())
+   @run.command()
    @click.pass_context
    def delete_index(ctx):
        """
@@ -118,7 +118,7 @@ While our function is named differently and has a different description, it's id
 
 .. code-block:: python
 
-   @run.command(context_settings=context_settings())
+   @run.command()
    @click.option('--index', help='An index name', type=str)
    @click.pass_context
    def delete_index(ctx, index):
@@ -181,7 +181,7 @@ logging:
 
 .. code-block:: python
 
-   @run.command(context_settings=context_settings())
+   @run.command()
    @click.option('--index', help='An index name', type=str)
    @click.pass_context
    def delete_index(ctx, index):
@@ -228,7 +228,7 @@ logic and see what happens:
 
 .. code-block:: python
 
-   @run.command(context_settings=context_settings())
+   @run.command()
    @click.option('--index', help='An index name', type=str)
    @click.pass_context
    def delete_index(ctx, index):
@@ -278,7 +278,7 @@ Begin the COPY PASTE! GO!
 
 .. code-block:: python
 
-   @run.command(context_settings=context_settings())
+   @run.command()
    @click.option('--index', help='An index name', type=str)
    @click.pass_context
    def create_index(ctx, index):
@@ -379,7 +379,7 @@ With the ``confirmation_option()`` decorator, Like this:
 
 .. code-block:: python
 
-   @run.command(context_settings=context_settings())
+   @run.command()
    @click.option('--index', help='An index name', type=str)
    @click.confirmation_option()
    @click.pass_context

--- a/es_client/cli_example.py
+++ b/es_client/cli_example.py
@@ -132,8 +132,14 @@ def run(ctx, config, hosts, cloud_id, api_token, id, api_key, username, password
 # @click_opt_wrap(*cli_opts('logformat', settings=LOGGING_SETTINGS, override=OVERRIDE))
 # @click_opt_wrap(*cli_opts('blacklist', settings=LOGGING_SETTINGS, override=OVERRIDE))
 
+### NOTE: Different procedure for show_all_options than other sub-commands
+# Normally, for a sub-command, you would not reset the `context_settings` as we've done here
+# because it also resets the context (ctx). We normally want to pass this along from the top level
+# command. In this case, we want it to look like the root-level command for the sake of the
+# environment variables being shown for the root-level and not a sub-level command.
+
 # pylint: disable=unused-argument, redefined-builtin, too-many-arguments, too-many-locals, line-too-long
-@run.command(short_help='Show all configuration options')
+@run.command(context_settings=context_settings(), short_help='Show all configuration options')
 @options_from_dict(SHOW_EVERYTHING)
 @click.version_option(None, '-v', '--version', prog_name="cli_example")
 @click.pass_context

--- a/es_client/defaults.py
+++ b/es_client/defaults.py
@@ -50,12 +50,11 @@ CLICK_SETTINGS: list = {
     'request_timeout': {'help': 'Request timeout in seconds', 'type': float},
     'http_compress': {
         'help': 'Enable HTTP compression',
-        'default': False,
-        'show_default': True,
+        'default': None,
         'hidden': True,
     },
     'verify_certs': {
-        'help': 'Verify SSL/TLS certificate(s)', 'default': True, 'show_default': True},
+        'help': 'Verify SSL/TLS certificate(s)', 'default': None},
     'ca_certs': {'help': 'Path to CA certificate file or directory', 'type': str},
     'client_cert': {'help': 'Path to client certificate file', 'type': str},
     'client_key': {'help': 'Path to client key file', 'type': str},
@@ -76,14 +75,12 @@ CLICK_SETTINGS: list = {
     'ssl_version': {'help': 'Minimum acceptable TLS/SSL version', 'type': str, 'hidden': True},
     'master-only': {
         'help': 'Only run if the single host provided is the elected master',
-        'default': False,
-        'show_default': True,
+        'default': None,
         'hidden': True
     },
     'skip_version_test': {
         'help': 'Elasticsearch version compatibility check',
-        'default': False,
-        'show_default': True,
+        'default': None,
         'hidden': True
     }
 }
@@ -95,16 +92,16 @@ ES_DEFAULT: dict = {'elasticsearch':{'client':{'hosts':['http://127.0.0.1:9200']
 ENV_VAR_PREFIX: str = 'ESCLIENT'
 """Environment variable prefix"""
 
-LOGLEVEL: str = 'INFO'
+LOGLEVEL: None = None
 """Default loglevel"""
 
 LOGFILE: None = None
 """Default value for logfile"""
 
-LOGFORMAT: str = 'default'
+LOGFORMAT: None = None
 """Default value for logformat"""
 
-BLACKLIST: list = ['elastic_transport', 'urllib3']
+BLACKLIST: None = None
 """Default value for logging blacklist"""
 
 LOGDEFAULTS: dict = {
@@ -119,18 +116,18 @@ LOGGING_SETTINGS: dict = {
     'loglevel': {
         'help': 'Log level',
         'type': Choice(['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']),
-        'default': LOGLEVEL
+        'default': None
     },
     'logfile': {'help': 'Log file', 'type': str},
     'logformat': {
         'help': 'Log output format',
         'type': Choice(['default', 'json', 'ecs']),
-        'default': LOGFORMAT
+        'default': None
     },
     'blacklist': {
         'help': 'Named entities will not be logged',
         'multiple': True,
-        'default': BLACKLIST,
+        'default': None,
         'hidden': True,
     },
 }

--- a/es_client/helpers/config.py
+++ b/es_client/helpers/config.py
@@ -463,6 +463,8 @@ def override_client_args(ctx: Context) -> None:
     args = prune_nones(args)
     # Update the object if we have settings to override after pruning None values
     if args:
+        for arg in args:
+            logger.debug('Using value for %s provided as a command-line option', arg)
         ctx.obj['client_args'].update_settings(args)
     # Use a default hosts value of localhost:9200 if there is no host and no cloud_id set
     if ctx.obj['client_args'].hosts is None and ctx.obj['client_args'].cloud_id is None:
@@ -482,6 +484,7 @@ def override_other_args(ctx: Context) -> None:
 
     Update :py:attr:`ctx.obj['other_args'] <click.Context.obj>` with the results.
     """
+    logger = logging.getLogger(__name__)
     apikey = prune_nones({
         'id': ctx.params['id'],
         'api_key': ctx.params['api_key'],
@@ -501,6 +504,8 @@ def override_other_args(ctx: Context) -> None:
         del args['api_key']
 
     if args:
+        for arg in args:
+            logger.debug('Using value for %s provided as a command-line option', arg)
         ctx.obj['other_args'].update_settings(args)
 
 def override_settings(settings: dict, override: dict) -> dict:

--- a/es_client/version.py
+++ b/es_client/version.py
@@ -1,2 +1,2 @@
 """Release version"""
-__version__ = '8.12.8'
+__version__ = '8.12.9'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "ecs-logging==2.1.0",
     "click==8.1.7",
     "pyyaml==6.0.1",
-    "voluptuous>=0.14.1",
+    "voluptuous>=0.14.2",
     "certifi>=2024.2.2",
     "six==1.16.0",
 ]


### PR DESCRIPTION
**Bugfix**

  * Reported in #1708. Default values (rather than None values) were overriding what was in config files. As a result, these default values from command-line settings were overriding important settings which were set properly in the configuration file. Hat tip to @rgaduput for reporting this.

**Changes**

  * Updated cli_example.py to make the ``show_all_options`` sub-command show the proper environment variables. This entailed resetting the context_settings. A note explaining the why is now in the comments above that function.
  * Updates to reflect the default values in the command-line were made in the tutorial and example documentation pages.
  * A new documentation page was created specific to environment variables.
  * Version bump ``voluptuous==0.14.2`` from ``0.14.1``

Fixes #1708