### PR TITLE
Release prep for 8.14.0

### DIFF
--- a/docker_test/create.sh
+++ b/docker_test/create.sh
@@ -27,9 +27,8 @@ mkdir -p ${REPOLOCAL}
 #####################
 
 # Start the container
-echo "Starting container \"${NAME}\" from ${IMAGE}:${VERSION}"
-echo -en "Container ID: "
-docker run -d -it --name ${NAME} -m ${MEMORY} \
+echo -en "\rStarting ${NAME} container... "
+docker run -d -it --name ${NAME} -m ${HEAP} \
   -p ${LOCAL_PORT}:${DOCKER_PORT} \
   -v ${REPOLOCAL}:${REPODOCKER} \
   -e "discovery.type=single-node" \
@@ -39,18 +38,6 @@ docker run -d -it --name ${NAME} -m ${MEMORY} \
   -e "path.repo=${REPODOCKER}" \
 ${IMAGE}:${VERSION}
 
-# Set the URL
-URL=https://${URL_HOST}:${LOCAL_PORT}
-
-# Add TESTPATH to ${ENVCFG}, creating it or overwriting it
-echo "export CA_CRT=${PROJECT_ROOT}/http_ca.crt" >> ${ENVCFG}
-echo "export TEST_PATH=${TESTPATH}" >> ${ENVCFG}
-echo "export TEST_ES_SERVER=${URL}" >> ${ENVCFG}
-echo "export TEST_ES_REPO=${REPONAME}" >> ${ENVCFG}
-
-# Write some ESCLIENT_ environment variables to the .env file  
-echo "export ESCLIENT_CA_CERTS=${CACRT}" >> ${ENVCFG}
-echo "export ESCLIENT_HOSTS=${URL}" >> ${ENVCFG}
 
 # Set up the curl config file, first line creates a new file, all others append
 echo "-o /dev/null" > ${CURLCFG}
@@ -68,8 +55,17 @@ if [ $? -eq 1 ]; then
   exit 1
 fi
 
+# Set the URL
+URL=https://${URL_HOST}:${LOCAL_PORT}
+
+# Write the TEST_ES_SERVER environment variable to the .env file
+echo "export TEST_ES_SERVER=${URL}" >> ${ENVCFG}
+
 # We expect a 200 HTTP rsponse
 EXPECTED=200
+
+# Set the NODE var
+NODE="${NAME} instance"
 
 # Start with an empty value
 ACTUAL=0
@@ -78,19 +74,17 @@ ACTUAL=0
 COUNTER=0
 
 # Loop until we get our 200 code
-echo
 while [ "${ACTUAL}" != "${EXPECTED}" ] && [ ${COUNTER} -lt ${LIMIT} ]; do
 
   # Get our actual response
   ACTUAL=$(curl -K ${CURLCFG} ${URL})
 
   # Report what we received
-  echo -en "\rWaiting for Elasticsearch. HTTP Status Code: ${ACTUAL}"
+  echo -en "\rHTTP status code for ${NODE} is: ${ACTUAL}"
 
   # If we got what we expected, we're great!
   if [ "${ACTUAL}" == "${EXPECTED}" ]; then
-    echo
-    echo "Elasticsearch is ready!"
+    echo " --- ${NODE} is ready!"
 
   else
     # Otherwise sleep and try again 
@@ -109,63 +103,15 @@ if [ "${ACTUAL}" != "${EXPECTED}" ]; then
 
 fi
 
-# Initialize trial license
-echo
-response=$(curl -s \
-  --cacert ${CACRT} -u "${ESUSR}:${ESPWD}" \
-  -XPOST "${URL}/_license/start_trial?acknowledge=true")
-
-expected='{"acknowledged":true,"trial_was_started":true,"type":"trial"}'
-if [ "$response" != "$expected" ]; then
-  echo "ERROR! Unable to start trial license!"
-else
-  echo -n "Trial license started and acknowledged. "
-fi
-
-# Set up snapshot repository. The following will create a JSON file suitable for use with
-# curl -d @filename
-
-rm -f ${REPOJSON}  
-
-echo    '{'                    >> $REPOJSON
-echo    '  "type": "fs",'      >> $REPOJSON
-echo    '  "settings": {'      >> $REPOJSON
-echo -n '    "location": "'    >> $REPOJSON
-echo -n "${REPODOCKER}"        >> $REPOJSON
-echo    '"'                    >> $REPOJSON
-echo    '  }'                  >> $REPOJSON
-echo    '}'                    >> $REPOJSON
-
-# Create snapshot repository
-response=$(curl -s \
-  --cacert ${CACRT} -u "${ESUSR}:${ESPWD}" \
-  -H 'Content-Type: application/json' \
-  -XPOST "${URL}/_snapshot/${REPONAME}?verify=false" \
-  --json \@${REPOJSON})
-
-expected='{"acknowledged":true}'
-if [ "$response" != "$expected" ]; then
-  echo "ERROR! Unable to create snapshot repository"
-else
-  echo "Snapshot repository \"${REPONAME}\" created."
-  # Put ESCLIENT_ env var export here?
-fi
-
-
 ##################
 ### Wrap it up ###
 ##################
 
 echo
-echo "Elasticsearch container \"${NAME}\" is up!"
-echo "Ready to test!"
-echo
+echo "${NAME} container is up using image elasticsearch:${VERSION}"
 
-if [ "$EXECPATH" == "$PROJECT_ROOT" ]; then
-  echo "Environment variables are in .env"
-elif [ "$EXECPATH" == "$SCRIPTPATH" ]; then
-  echo "\$PWD is $SCRIPTPATH." 
-  echo "Environment variables are in ../.env"
-else
-  echo "Environment variables are in ${PROJECT_ROOT}/.env"
-fi
+echo
+echo "Environment variables are in \$PROJECT_ROOT/.env"
+
+echo
+echo "Ready to test!"

--- a/docker_test/destroy.sh
+++ b/docker_test/destroy.sh
@@ -13,9 +13,9 @@ echo "$(docker rm ${NAME}) deleted."
 # Delete .env file and curl config file
 echo "Deleting remaining files and directories"
 rm -rf ${REPOLOCAL}
-rm -f ${SCRIPTPATH}/${REPOJSON}
+rm -f ${SCRIPTPATH}/Dockerfile
 rm -f ${ENVCFG}
 rm -f ${CURLCFG}
-rm -f ${PROJECT_ROOT}/http_ca.crt
+rm -f ${TESTPATH}/http_ca.crt
 
 echo "Cleanup complete."

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,26 @@
 Changelog
 =========
 
+8.14.0 (3 July 2024)
+--------------------
+
+**Changes**
+
+  * Python module version bumps:
+      * ``elasticsearch8==8.14.0``
+      * ``ecs-logging==2.2.0``
+      * ``voluptuous>=0.15.2``
+      * ``certifi>=2024.6.2``
+  * Updated remainint tests to Pytest-style formatting.
+  * Updated ``docker_test`` scripts to most recent updates.
+
+**Bugfix**
+
+  * Fixed an error reported at https://github.com/elastic/curator/issues/1713
+    where providing an empty API ``token`` key would still result in the Builder
+    class method ``_check_api_key`` trying to extract data. Locally tracked at
+    https://github.com/untergeek/es_client/issues/66 
+
 8.13.5 (7 May 2024)
 -------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.12", None),
-    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.13.1", None),
+    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.14.0", None),
     "elastic-transport": (
         "https://elastic-transport-python.readthedocs.io/en/stable",
         None,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-elasticsearch8==8.13.1
-voluptuous>=0.14.2
+elasticsearch8==8.14.0
+voluptuous>=0.15.2
 pyyaml==6.0.1
 pint>=0.19.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,13 @@ keywords = [
     'command-line'
 ]
 dependencies = [
-    'elasticsearch8==8.13.1',
-    'ecs-logging==2.1.0',
+    'elasticsearch8==8.14.0',
+    'ecs-logging==2.2.0',
     'dotmap==1.3.30',
     'click==8.1.7',
     'pyyaml==6.0.1',
-    'voluptuous>=0.14.2',
-    'certifi>=2024.2.2',
+    'voluptuous>=0.15.2',
+    'certifi>=2024.6.2',
     'six==1.16.0',
 ]
 

--- a/src/es_client/__init__.py
+++ b/src/es_client/__init__.py
@@ -3,4 +3,4 @@
 from .builder import Builder
 
 __all__ = ["Builder"]
-__version__ = "8.13.5"
+__version__ = "8.14.0"

--- a/src/es_client/builder.py
+++ b/src/es_client/builder.py
@@ -262,9 +262,10 @@ class Builder:
             # If present, token will override any value in 'id' or 'api_key'
             # pylint: disable=no-member
             if "token" in self.other_args.api_key:
-                (self.other_args.api_key.id, self.other_args.api_key.api_key) = (
-                    parse_apikey_token(self.other_args.api_key.token)
-                )
+                if self.other_args.api_key.token is not None:
+                    (self.other_args.api_key.id, self.other_args.api_key.api_key) = (
+                        parse_apikey_token(self.other_args.api_key.token)
+                    )
             if "id" in self.other_args.api_key or "api_key" in self.other_args.api_key:
                 api_id = (
                     self.other_args.api_key.id

--- a/tests/integration/test_builder.py
+++ b/tests/integration/test_builder.py
@@ -1,6 +1,7 @@
 """Test the Builder class"""
 
 from unittest import TestCase
+import pytest
 from es_client.builder import Builder
 from es_client.exceptions import ConfigurationError, ESClientException, NotMaster
 from . import CACRT, HOST, PASS, USER
@@ -35,7 +36,8 @@ class TestCheckMaster(TestCase):
         }
         obj = Builder(configdict=local_conf, autoconnect=False)
         obj._get_client()
-        self.assertRaises(ConfigurationError, obj._check_master)
+        with pytest.raises(ConfigurationError):
+            obj._check_master()
 
     def test_exit_if_not_master(self):
         """Raise NotMaster if node is not master"""
@@ -43,7 +45,8 @@ class TestCheckMaster(TestCase):
         obj.master_only = True
         obj.is_master = False
         obj._get_client()
-        self.assertRaises(NotMaster, obj._check_master)
+        with pytest.raises(NotMaster):
+            obj._check_master()
 
 
 class TestCheckVersion(TestCase):
@@ -54,7 +57,7 @@ class TestCheckVersion(TestCase):
         obj = Builder(configdict=config, autoconnect=False)
         obj.skip_version_test = True
         obj._get_client()
-        self.assertIsNone(obj._check_version())
+        assert obj._check_version() is None
 
     def test_bad_version_raises(self):
         """Raise ESClientException if version is out of bounds"""
@@ -62,7 +65,8 @@ class TestCheckVersion(TestCase):
         obj.version_min = (98, 98, 98)
         obj.version_max = (99, 99, 99)
         obj._get_client()
-        self.assertRaises(ESClientException, obj._check_version)
+        with pytest.raises(ESClientException):
+            obj._check_version()
 
 
 class TestConnection(TestCase):
@@ -71,11 +75,12 @@ class TestConnection(TestCase):
     def test_incomplete_dict_passed(self):
         """Sending a proper dictionary but None value for hosts will raise ValueError"""
         cfg = {"elasticsearch": {"client": {"hosts": None}}}
-        self.assertRaises(ValueError, Builder, configdict=cfg, autoconnect=True)
+        with pytest.raises(ValueError):
+            Builder(configdict=cfg, autoconnect=True)
 
     def test_client_info(self):
         """Proper connection to client makes for a good response"""
         obj = Builder(configdict=config, autoconnect=True)
         client = obj.client
         expected = client.info()
-        self.assertEqual(expected, obj.test_connection())
+        assert expected == obj.test_connection()

--- a/tests/integration/test_cli_example.py
+++ b/tests/integration/test_cli_example.py
@@ -5,6 +5,18 @@ from unittest import TestCase
 from click import testing as clicktest
 from es_client.cli_example import run
 from . import CACRT, HOST, PASS, USER
+from ..unit import FileTestObj
+
+YAMLCONFIG = "\n".join(
+    [
+        "---",
+        "logging:",
+        "  loglevel: INFO",
+        "  logfile:",
+        "  logformat: default",
+        "  blacklist: ['elastic_transport', 'urllib3']",
+    ]
+)
 
 
 class TestCLIExample(TestCase):
@@ -27,14 +39,14 @@ class TestCLIExample(TestCase):
         ]
         runner = clicktest.CliRunner()
         result = runner.invoke(run, args)
-        self.assertEqual(0, result.exit_code)
+        assert result.exit_code == 0
 
     def test_show_all_options(self):
         """Ensure show-all-options works"""
         args = ["show-all-options"]
         runner = clicktest.CliRunner()
         result = runner.invoke(run, args=args)
-        self.assertEqual(0, result.exit_code)
+        assert result.exit_code == 0
 
     def test_logging_options_json(self):
         """Testing JSON log options"""
@@ -55,7 +67,7 @@ class TestCLIExample(TestCase):
         ]
         runner = clicktest.CliRunner()
         result = runner.invoke(run, args=args)
-        self.assertEqual(0, result.exit_code)
+        assert result.exit_code == 0
 
     def test_logging_options_ecs(self):
         """Testing ECS log options"""
@@ -78,4 +90,29 @@ class TestCLIExample(TestCase):
         ]
         runner = clicktest.CliRunner()
         result = runner.invoke(run, args)
-        self.assertEqual(0, result.exit_code)
+        assert result.exit_code == 0
+
+    def test_logging_options_from_config_file(self):
+        """Testing logging options from a config file"""
+        # Build
+        file_obj = FileTestObj()
+        file_obj.write_config(file_obj.args["configfile"], YAMLCONFIG)
+        # Test
+        args = [
+            "--config",
+            file_obj.args["configfile"],
+            "--hosts",
+            HOST,
+            "--username",
+            USER,
+            "--password",
+            PASS,
+            "--ca_certs",
+            CACRT,
+            "test-connection",
+        ]
+        runner = clicktest.CliRunner()
+        result = runner.invoke(run, args)
+        assert result.exit_code == 0
+        # Teardown
+        file_obj.teardown()

--- a/tests/integration/test_helpers_config.py
+++ b/tests/integration/test_helpers_config.py
@@ -1,6 +1,7 @@
 """Test helpers.config"""
 
 from unittest import TestCase
+import pytest
 from dotmap import DotMap  # type: ignore
 from elasticsearch8 import Elasticsearch
 from es_client.defaults import ES_DEFAULT
@@ -21,10 +22,12 @@ class TestGetClient(TestCase):
 
     def test_basic_operation(self):
         """Ensure basic operation"""
-        self.assertTrue(isinstance(config.get_client(configdict=CONFIG), Elasticsearch))
+        assert isinstance(config.get_client(configdict=CONFIG), Elasticsearch)
 
     def test_raises_when_no_connection(self):
-        """Ensures that an exception is raised when it cannot connect to Elasticsearch"""
+        """
+        Ensures that an exception is raised when it cannot connect to Elasticsearch
+        """
         client_args = DotMap()
         other_args = DotMap()
         client_args.update(DotMap(ES_DEFAULT))
@@ -36,4 +39,5 @@ class TestGetClient(TestCase):
                 "other_settings": other_args.toDict(),
             }
         }
-        self.assertRaises(ESClientException, config.get_client, configdict=cnf)
+        with pytest.raises(ESClientException):
+            _ = config.get_client(configdict=cnf)

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -12,8 +12,10 @@ from es_client.helpers.utils import option_wrapper, prune_nones
 
 ONOFF = {"on": "", "off": "no-"}
 
+DEFAULT_HOST = "http://127.0.0.1:9200"
+
 DEFAULTCFG = "\n".join(
-    ["---", "elasticsearch:", "  client:", '    hosts: ["http://127.0.0.1:9200"]']
+    ["---", "elasticsearch:", "  client:", f"    hosts: [{DEFAULT_HOST}]"]
 )
 
 EMPTYCFG = (
@@ -32,7 +34,7 @@ YAMLCONFIG = (
     "---\n"
     "elasticsearch:\n"
     "  client:\n"
-    '    hosts: ["http://127.0.0.1:9200"]\n'
+    f"    hosts: [{DEFAULT_HOST}]\n"
     "  other_settings:\n"
     "    username: {0}\n"
     "    password: {1}\n"
@@ -92,7 +94,7 @@ class FileTestObj(object):
             f.write(data)
 
 
-# pylint: disable=unused-argument, redefined-builtin, too-many-arguments, too-many-locals, line-too-long
+# pylint: disable=unused-argument, redefined-builtin, too-many-arguments
 @click.command()
 @click_opt_wrap(*cfgfn.cli_opts("config"))
 @click_opt_wrap(*cfgfn.cli_opts("hosts"))
@@ -223,7 +225,6 @@ def default_config_cmd(
     click.echo(f'{ctx.obj["configdict"]}')
 
 
-# pylint: disable=unused-argument, redefined-builtin, too-many-arguments, too-many-locals, line-too-long
 @click.command()
 @click_opt_wrap(*cfgfn.cli_opts("config"))
 @click_opt_wrap(*cfgfn.cli_opts("hosts"))

--- a/tests/unit/test_defaults.py
+++ b/tests/unit/test_defaults.py
@@ -1,15 +1,23 @@
 """Test functions in es_client.defaults"""
+
 from unittest import TestCase
-from es_client.defaults import CLIENT_SETTINGS, OTHER_SETTINGS, client_settings, other_settings
+from es_client.defaults import (
+    CLIENT_SETTINGS,
+    OTHER_SETTINGS,
+    client_settings,
+    other_settings,
+)
 
 
 class TestSettings(TestCase):
-    """Ensure test coverage of simple functions that might be deprecated in the future"""
+    """
+    Ensure test coverage of simple functions that might be deprecated in the future
+    """
 
     def test_client_settings(self):
         """Ensure matching output"""
-        self.assertEqual(CLIENT_SETTINGS, client_settings())
+        assert CLIENT_SETTINGS == client_settings()
 
     def test_other_settings(self):
         """Ensure matching output"""
-        self.assertEqual(OTHER_SETTINGS, other_settings())
+        assert OTHER_SETTINGS == other_settings()

--- a/tests/unit/test_helpers_logging.py
+++ b/tests/unit/test_helpers_logging.py
@@ -1,7 +1,16 @@
 """Test helpers.logging"""
 
 from unittest import TestCase
+import pytest
+import click
 from es_client.helpers.logging import check_logging_config, get_numeric_loglevel
+from es_client.helpers.utils import get_yaml
+from . import FileTestObj
+
+
+def process_cmd(key):
+    """Return the key from the click context's object"""
+    return click.get_current_context().obj[key]
 
 
 class TestCheckLoggingConfig(TestCase):
@@ -16,11 +25,36 @@ class TestCheckLoggingConfig(TestCase):
 
     def test_non_dict(self):
         """Ensure it yields default values"""
-        self.assertEqual(self.default, check_logging_config("not-a-dict"))
+        assert self.default == check_logging_config("not-a-dict")
 
     def test_empty_key(self):
         """Ensure it yields default values too"""
-        self.assertEqual(self.default, check_logging_config({"logging": {}}))
+        assert self.default == check_logging_config({"logging": {}})
+
+    def test_logging_context_for_empty_logfile(self):
+        """Test to see contents of ctx"""
+        yamlconfig = "\n".join(
+            [
+                "---",
+                "logging:",
+                "  loglevel: INFO",
+                "  logfile: ",
+                "  logformat: default",
+                "  blacklist: ['elastic_transport', 'urllib3']",
+            ]
+        )
+        # Build
+        file_obj = FileTestObj()
+        file_obj.write_config(file_obj.args["configfile"], yamlconfig)
+        # Test
+        val = get_yaml(file_obj.args["configfile"])
+        key = 'draftcfg'
+        ctx = click.Context(click.Command('cmd'), obj={key: val})
+        with ctx:
+            resp = process_cmd(key)
+        assert resp['logging']['logfile'] is None
+        # Teardown
+        file_obj.teardown()
 
 
 class TestGetNumericLogLevel(TestCase):
@@ -28,4 +62,5 @@ class TestGetNumericLogLevel(TestCase):
 
     def test_invalid_loglevel(self):
         """Ensure it raises an exception when an invalid loglevel is provided"""
-        self.assertRaises(ValueError, get_numeric_loglevel, "NONSENSE")
+        with pytest.raises(ValueError):
+            get_numeric_loglevel("NONSENSE")

--- a/tests/unit/test_helpers_schemacheck.py
+++ b/tests/unit/test_helpers_schemacheck.py
@@ -1,6 +1,7 @@
 """Test helpers.schemacheck"""
 
 from unittest import TestCase
+import pytest
 from voluptuous import Schema
 from es_client.exceptions import FailedValidation
 from es_client.helpers.schemacheck import SchemaCheck
@@ -20,7 +21,8 @@ class TestSchemaCheck(TestCase):
         """Ensure that a bad port value Raises a FailedValidation"""
         config = {"elasticsearch": {"client": {"port": 70000}}}
         schema = SchemaCheck(config, config_schema(), "elasticsearch", "client")
-        self.assertRaises(FailedValidation, schema.result)
+        with pytest.raises(FailedValidation):
+            schema.result()
 
     def test_entirely_wrong_keys(self):
         """Ensure that unacceptable keys Raises a FailedValidation"""
@@ -32,13 +34,14 @@ class TestSchemaCheck(TestCase):
             "something_else": "foo",
         }
         schema = SchemaCheck(config, config_schema(), "elasticsearch", "client")
-        self.assertRaises(FailedValidation, schema.result)
+        with pytest.raises(FailedValidation):
+            schema.result()
 
     def test_does_not_password_filter_non_dict(self):
         """Ensure that if config is not a dictionary that it doesn't choke"""
         config = None
         schema = SchemaCheck(config, Schema(config), "arbitrary", "anylocation")
-        self.assertIsNone(schema.result(), Schema(None))
+        assert schema.result() is None
 
 
 class TestVersionMinMax(TestCase):

--- a/tests/unit/test_helpers_utils.py
+++ b/tests/unit/test_helpers_utils.py
@@ -45,19 +45,21 @@ class TestEnsureList(TestCase):
     """Test the u.ensure_list function"""
 
     def test_utils_ensure_list_returns_lists(self):
-        """Test several examples of lists: existing lists, strings, mixed lists/numbers, etc."""
+        """
+        Test several examples of lists: existing lists, strings, mixed lists/numbers
+        """
         verify = ["a", "b", "c", "d"]
         source = ["a", "b", "c", "d"]
-        self.assertEqual(verify, u.ensure_list(source))
+        assert verify == u.ensure_list(source)
         verify = ["abcd"]
         source = "abcd"
-        self.assertEqual(verify, u.ensure_list(source))
+        assert verify == u.ensure_list(source)
         verify = [["abcd", "defg"], 1, 2, 3]
         source = [["abcd", "defg"], 1, 2, 3]
-        self.assertEqual(verify, u.ensure_list(source))
+        assert verify == u.ensure_list(source)
         verify = [{"a": "b", "c": "d"}]
         source = {"a": "b", "c": "d"}
-        self.assertEqual(verify, u.ensure_list(source))
+        assert verify == u.ensure_list(source)
 
 
 class TestPruneNones(TestCase):
@@ -65,12 +67,12 @@ class TestPruneNones(TestCase):
 
     def test_utils_prune_nones_with(self):
         """Ensure that a dict with a single None value comes back as an empty dict"""
-        self.assertEqual({}, u.prune_nones({"a": None}))
+        assert not u.prune_nones({"a": None})
 
     def test_utils_prune_nones_without(self):
         """Ensure that a dict with no None values comes back unchanged"""
         testval = {"foo": "bar"}
-        self.assertEqual(testval, u.prune_nones(testval))
+        assert testval == u.prune_nones(testval)
 
 
 class TestReadFile:
@@ -133,7 +135,9 @@ class TestEnvVars:
         obj.teardown()
 
     def test_not_present_with_default(self):
-        """Test a non-existent (not-present) envvar. It should set a default value here"""
+        """
+        Test a non-existent (not-present) envvar. It should set a default value here
+        """
         obj = FileTestObj()
         evar = random_envvar(8)
         default = random_envvar(8)
@@ -168,13 +172,17 @@ class TestVerifyURLSchema:
         assert u.verify_url_schema(url) == url
 
     def test_http_schema_no_port(self):
-        """Verify that port 80 is tacked on when no port is specified as a port is required"""
+        """
+        Verify that port 80 is tacked on when no port is specified as a port is required
+        """
         http_port = "80"
         url = "http://127.0.0.1"
         assert u.verify_url_schema(url) == "http://127.0.0.1" + ":" + http_port
 
     def test_https_schema_no_port(self):
-        """Verify that 443 is tacked on when no port is specified but https is the schema"""
+        """
+        Verify that 443 is tacked on when no port is specified but https is the schema
+        """
         https_port = "443"
         url = "https://127.0.0.1"
         assert u.verify_url_schema(url) == "https://127.0.0.1" + ":" + https_port


### PR DESCRIPTION
### Changes

  * Python module version bumps:
    * ``elasticsearch8==8.14.0``
    * ``ecs-logging==2.2.0``
    * ``voluptuous>=0.15.2``
    * ``certifi>=2024.6.2``
  * Updated remainint tests to Pytest-style formatting.
  * Updated ``docker_test`` scripts to most recent updates.

### Bug Fixes

  * Fixed an error reported at https://github.com/elastic/curator/issues/1713 where providing an empty API ``token`` key would still result in the Builder class method ``_check_api_key`` trying to extract data. Locally tracked at https://github.com/untergeek/es_client/issues/66

Fixes #66