### PR TITLE
Release prep for 8.14.1

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,14 @@
 Changelog
 =========
 
+8.14.1 (6 August 2024)
+----------------------
+
+**Changes**
+
+  * ``six`` module removed.
+  * Rolled back ``voluptuous`` to be ``>=0.14.2`` to work with Python 3.8
+
 8.14.0 (3 July 2024)
 --------------------
 
@@ -13,7 +21,7 @@ Changelog
       * ``ecs-logging==2.2.0``
       * ``voluptuous>=0.15.2``
       * ``certifi>=2024.6.2``
-  * Updated remainint tests to Pytest-style formatting.
+  * Updated remaining tests to Pytest-style formatting.
   * Updated ``docker_test`` scripts to most recent updates.
 
 **Bugfix**

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
 elasticsearch8==8.14.0
-voluptuous>=0.15.2
+voluptuous>=0.14.2
 pyyaml==6.0.1
 pint>=0.19.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,9 +32,8 @@ dependencies = [
     'dotmap==1.3.30',
     'click==8.1.7',
     'pyyaml==6.0.1',
-    'voluptuous>=0.15.2',
-    'certifi>=2024.6.2',
-    'six==1.16.0',
+    'voluptuous>=0.14.2',
+    'certifi>=2024.6.2'
 ]
 
 [project.optional-dependencies]

--- a/src/es_client/__init__.py
+++ b/src/es_client/__init__.py
@@ -3,4 +3,4 @@
 from .builder import Builder
 
 __all__ = ["Builder"]
-__version__ = "8.14.0"
+__version__ = "8.14.1"


### PR DESCRIPTION
**Changes**

  * ``six`` module removed.
  * Rolled back ``voluptuous`` to be ``>=0.14.2`` to work with Python 3.8