### PR TITLE
Release prep for 8.15.0

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,5 +1,6 @@
 """CLI Wrapper used by cli.py"""
-import click
+
+from click import echo
 from es_client.cli_example import run
 
 if __name__ == '__main__':
@@ -7,7 +8,8 @@ if __name__ == '__main__':
         # This is because click uses decorators, and pylint doesn't catch that
         # pylint: disable=no-value-for-parameter
         run()
-    except RuntimeError as e:
+    except RuntimeError as err:
         import sys
-        print('{0}'.format(e))
+
+        echo(f'{err}')
         sys.exit(1)

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,15 @@
 Changelog
 =========
 
+8.15.0 (13 August 2024)
+-----------------------
+
+**Changes**
+
+  * Python module version bumps:
+    * ``elasticsearch8==8.15.0``
+  * Make execution scripts more consistent and PEP compliant.
+
 8.14.2 (6 August 2024)
 ----------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.12", None),
-    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.14.0", None),
+    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.15.0", None),
     "elastic-transport": (
         "https://elastic-transport-python.readthedocs.io/en/stable",
         None,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-elasticsearch8==8.14.0
+elasticsearch8==8.15.0
 voluptuous>=0.14.2
 pyyaml==6.0.1
 pint>=0.19.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ keywords = [
     'command-line'
 ]
 dependencies = [
-    'elasticsearch8==8.14.0',
+    'elasticsearch8==8.15.0',
     'ecs-logging==2.2.0',
     'dotmap==1.3.30',
     'click==8.1.7',

--- a/run_script.py
+++ b/run_script.py
@@ -1,19 +1,16 @@
 #!/usr/bin/env python
-# pylint: disable=broad-except, no-value-for-parameter
-"""
-Wrapper for running a script from source.
-"""
-import sys
-import click
+"""Script to run locally"""
+
+from click import echo
 from es_client.cli_example import run
 
 if __name__ == '__main__':
     try:
+        # This is because click uses decorators, and pylint doesn't catch that
+        # pylint: disable=no-value-for-parameter
         run()
     except RuntimeError as err:
-        click.echo(f'{err}')
+        import sys
+
+        echo(f'{err}')
         sys.exit(1)
-    except Exception as err:
-        if 'ASCII' in str(err):
-            click.echo(f'{err}')
-            click.echo(__doc__)

--- a/src/es_client/__init__.py
+++ b/src/es_client/__init__.py
@@ -3,4 +3,4 @@
 from .builder import Builder
 
 __all__ = ["Builder"]
-__version__ = "8.14.2"
+__version__ = "8.15.0"

--- a/src/local_test.py
+++ b/src/local_test.py
@@ -1,20 +1,16 @@
 #!/usr/bin/env python
+"""Script to run locally"""
 
-# pylint: disable=broad-except, no-value-for-parameter
-"""
-Wrapper for running a script from source.
-"""
-import sys
-import click
+from click import echo
 from es_client.cli_example import run
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     try:
+        # This is because click uses decorators, and pylint doesn't catch that
+        # pylint: disable=no-value-for-parameter
         run()
     except RuntimeError as err:
-        click.echo(f"{err}")
+        import sys
+
+        echo(f'{err}')
         sys.exit(1)
-    except Exception as err:
-        if "ASCII" in str(err):
-            click.echo(f"{err}")
-            click.echo(__doc__)


### PR DESCRIPTION
**Changes**

  * Python module version bumps:
    * ``elasticsearch8==8.15.0``
  * Make execution scripts more consistent and PEP compliant.