### PR TITLE
Release prep for 8.15.2

### DIFF
--- a/docker_test/VERSION
+++ b/docker_test/VERSION
@@ -1,4 +1,4 @@
-Version: 1.0.1
+Version: 1.0.2
 Released: 23 August 2024
 
 # License and Changelog at https://github.com/untergeek/es-docker-test-scripts

--- a/docker_test/create.sh
+++ b/docker_test/create.sh
@@ -157,6 +157,7 @@ if [ "$response" != "$expected" ]; then
   echo "ERROR! Unable to create snapshot repository"
 else
   echo "Snapshot repository \"${REPONAME}\" created."
+  rm -f ${REPOJSON}
 fi
 
 

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,17 @@
 Changelog
 =========
 
+8.15.2 (30 September 2024)
+--------------------------
+
+**Changes**
+
+  * Python module version bumps:
+    * ``elasticsearch8==8.15.1``
+    * ``pyyaml==6.0.2``
+    * ``certifi>=2024.8.30``
+
+
 8.15.1 (23 August 2024)
 -----------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.12", None),
-    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.15.0", None),
+    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.15.1", None),
     "elastic-transport": (
         "https://elastic-transport-python.readthedocs.io/en/stable",
         None,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-elasticsearch8==8.15.0
+elasticsearch8==8.15.1
 voluptuous>=0.14.2
-pyyaml==6.0.1
+pyyaml==6.0.2
 pint>=0.19.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,13 @@ keywords = [
     'command-line'
 ]
 dependencies = [
-    'elasticsearch8==8.15.0',
+    'elasticsearch8==8.15.1',
     'ecs-logging==2.2.0',
     'dotmap==1.3.30',
     'click==8.1.7',
-    'pyyaml==6.0.1',
+    'pyyaml==6.0.2',
     'voluptuous>=0.14.2',
-    'certifi>=2024.6.2'
+    'certifi>=2024.8.30'
 ]
 
 [project.optional-dependencies]

--- a/src/es_client/__init__.py
+++ b/src/es_client/__init__.py
@@ -3,4 +3,4 @@
 from .builder import Builder
 
 __all__ = ["Builder"]
-__version__ = "8.15.1"
+__version__ = "8.15.2"


### PR DESCRIPTION
* Python module version bumps:
  * ``elasticsearch8==8.15.1``
  * ``pyyaml==6.0.2``
  * ``certifi>=2024.8.30``

Release version 8.15.2