### PR TITLE
Release 8.17.1 prep

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,31 @@
 Changelog
 =========
 
+8.17.1 (24 Janary 2025)
+-----------------------
+
+**Announcements**
+
+  * Python 3.13 support...but with a caveat.
+    * HUGE (potential) caveat, though. The Python 3.13 SSL implementation now has
+      ``X509_V_FLAG_X509_STRICT`` set by default. This unfortunately means that
+      self-signed certificates created by Elasticsearch's ``certutil`` will not
+      work with Python 3.13 as they do not yet include the key usage extension.
+      If you are using ``es_client`` in any way with one of these certificates,
+      I highly recommend that you not use Python 3.13 until this is resolved.
+    * 3.13 is excluded from the Hatch test matrix for this reason.
+    * 3.13 will still be tested manually with each release.
+  
+**Changes**
+
+  * Python module version bumps:
+    * ``elasticsearch8==8.17.1``
+    * ``click==8.1.8``
+    * ``certifi>=2024.12.14``
+  * Refactored ``master_only`` functions and tests. I discovered some loopholes
+    in my code when I was testing Python 3.13 against an Elastic Cloud instance,
+    so I fixed them. This also necessitated a change in the integration tests.
+
 8.15.2 (30 September 2024)
 --------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.12", None),
-    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.15.1", None),
+    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.17.1", None),
     "elastic-transport": (
         "https://elastic-transport-python.readthedocs.io/en/stable",
         None,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-elasticsearch8==8.15.1
+elasticsearch8==8.17.1
 voluptuous>=0.14.2
 pyyaml==6.0.2
 pint>=0.19.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
 ]
 keywords = [
     'elasticsearch',
@@ -27,19 +28,19 @@ keywords = [
     'command-line'
 ]
 dependencies = [
-    'elasticsearch8==8.15.1',
+    'elasticsearch8==8.17.1',
     'ecs-logging==2.2.0',
     'dotmap==1.3.30',
-    'click==8.1.7',
+    'click==8.1.8',
     'pyyaml==6.0.2',
     'voluptuous>=0.14.2',
-    'certifi>=2024.8.30'
+    'certifi>=2024.12.14'
 ]
 
 [project.optional-dependencies]
 test = [
     'requests',
-    'pytest >=7.2.1',
+    'pytest>=7.2.1',
     'pytest-cov',
     'pytest-dotenv',
 ]

--- a/src/es_client/__init__.py
+++ b/src/es_client/__init__.py
@@ -3,4 +3,4 @@
 from .builder import Builder
 
 __all__ = ["Builder"]
-__version__ = "8.15.2"
+__version__ = "8.17.1"


### PR DESCRIPTION
  * Python 3.13 support...but with a caveat.
    * HUGE (potential) caveat, though. The Python 3.13 SSL implementation now has ``X509_V_FLAG_X509_STRICT`` set by default. This unfortunately means that [self-signed certificates created by Elasticsearch's ``certutil`` will not work with Python 3.13](https://github.com/elastic/elasticsearch/issues/117769) as they do not yet include the key usage extension. If you are using ``es_client`` in any way with one of these certificates, I highly recommend that you not use Python 3.13 until this is resolved.
    * 3.13 is excluded from the Hatch test matrix for this reason.
    * 3.13 will still be tested manually with each release.

  * Python module version bumps:
    * ``elasticsearch8==8.17.1``
    * ``click==8.1.8``
    * ``certifi>=2024.12.14``
  * Refactored ``master_only`` functions and tests. I discovered some loopholes in my code when I was testing Python 3.13 against an Elastic Cloud instance, so I fixed them. This also necessitated a change in the integration tests.