### PR TITLE
Release prep for v8.17.2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022-2025 Aaron Mildenstein
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,27 @@
 Changelog
 =========
 
+8.17.2 (26 February 2025)
+-------------------------
+
+**Announcement**
+
+  * Attempting to allow the 8.x client to work with 7.x Elasticsearch servers by
+    making ``min_version`` and ``max_version`` configurable at the time of
+    ``Builder`` instantiation.
+    The default values are still limited to 8.x versions, but preliminary testing
+    shows that the 8.x client works just fine for Curator against 7.14.x through
+    7.17.x servers with these changes.
+    
+**Changes**
+
+  * The ``Builder`` class can now override the default minimum and/or maximum version:
+    ``Builder(config, min_version=7.0.0, max_version=8.99.99)``.
+  * The ``helpers.config.get_client()`` function can also take these arguments:
+    ``helpers.config.get_client(config, min_version=7.0.0, max_version=8.99.99)``.
+  * Updated the date and copyright holder in ``LICENSE``.
+
+
 8.17.1 (24 Janary 2025)
 -----------------------
 

--- a/src/es_client/__init__.py
+++ b/src/es_client/__init__.py
@@ -3,4 +3,4 @@
 from .builder import Builder
 
 __all__ = ["Builder"]
-__version__ = "8.17.1"
+__version__ = "8.17.2"

--- a/src/es_client/builder.py
+++ b/src/es_client/builder.py
@@ -43,6 +43,8 @@ class Builder:
         configdict: t.Union[t.Dict, None] = None,
         configfile: t.Union[str, None] = None,
         autoconnect: bool = False,
+        version_min: t.Tuple = VERSION_MIN,
+        version_max: t.Tuple = VERSION_MAX,
     ):
         #: The DotMap storage for attributes and settings
         self.attributes = DotMap()
@@ -51,8 +53,8 @@ class Builder:
         #: The :py:class:`~.elasticsearch.Elasticsearch` client connection object
         self.client = elasticsearch8.Elasticsearch(hosts="http://127.0.0.1:9200")
         self.process_config_opts(configdict, configfile)
-        self.version_max = VERSION_MAX
-        self.version_min = VERSION_MIN
+        self.version_max = version_max
+        self.version_min = version_min
         self.update_config()
         self.validate()
         if autoconnect:

--- a/src/es_client/helpers/config.py
+++ b/src/es_client/helpers/config.py
@@ -7,7 +7,13 @@ from dotmap import DotMap  # type: ignore
 from click import Context, secho, option as clickopt
 from elasticsearch8 import Elasticsearch
 from es_client.builder import Builder
-from es_client.defaults import CLICK_SETTINGS, ENV_VAR_PREFIX, config_settings
+from es_client.defaults import (
+    CLICK_SETTINGS,
+    ENV_VAR_PREFIX,
+    VERSION_MIN,
+    VERSION_MAX,
+    config_settings,
+)
 from es_client.exceptions import ESClientException, ConfigurationError
 from es_client.helpers.utils import (
     check_config,
@@ -285,6 +291,8 @@ def get_client(
     configdict: t.Union[t.Dict, None] = None,
     configfile: t.Union[str, None] = None,
     autoconnect: bool = False,
+    version_min: t.Tuple = VERSION_MIN,
+    version_max: t.Tuple = VERSION_MAX,
 ) -> Elasticsearch:
     """
     :param configdict: A configuration dictionary
@@ -309,7 +317,11 @@ def get_client(
     logger.debug("Creating client object and testing connection")
 
     builder = Builder(
-        configdict=configdict, configfile=configfile, autoconnect=autoconnect
+        configdict=configdict,
+        configfile=configfile,
+        autoconnect=autoconnect,
+        version_max=version_max,
+        version_min=version_min,
     )
 
     try:


### PR DESCRIPTION
**Announcement**

  * Attempting to allow the 8.x client to work with 7.x Elasticsearch servers by
    making ``min_version`` and ``max_version`` configurable at the time of
    ``Builder`` instantiation.
    The default values are still limited to 8.x versions, but preliminary testing
    shows that the 8.x client works just fine for Curator against 7.14.x through
    7.17.x servers with these changes.
    
**Changes**

  * The ``Builder`` class can now override the default minimum and/or maximum version:
    ``Builder(config, min_version=7.0.0, max_version=8.99.99)``.
  * The ``helpers.config.get_client()`` function can also take these arguments:
    ``helpers.config.get_client(config, min_version=7.0.0, max_version=8.99.99)``.
  * Updated the date and copyright holder in ``LICENSE``.