### PR TITLE
Patch release of 8.17.4

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,20 @@
 Changelog
 =========
 
+8.17.4 (18 March 2025)
+----------------------
+
+**Bugfix**
+
+  * Fixed a logging configuration bug to only assign a file handler if a log file
+    is specified. Also fixed to ensure configuration goes to the root logger.
+
+**Changes**
+
+  * Dependency version bumps in this release:
+      * ``elasticsearch8==8.17.2``
+      * ``certifi>=2025.3.31``
+
 8.17.3 (6 March 2025)
 ---------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,7 +66,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.12", None),
-    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.17.1", None),
+    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.17.2", None),
     "elastic-transport": (
         "https://elastic-transport-python.readthedocs.io/en/stable",
         None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,13 @@ keywords = [
     'command-line'
 ]
 dependencies = [
-    'elasticsearch8==8.17.1',
+    'elasticsearch8==8.17.2',
     'ecs-logging==2.2.0',
     'dotmap==1.3.30',
     'click==8.1.8',
     'pyyaml==6.0.2',
     'voluptuous>=0.14.2',
-    'certifi>=2024.12.14'
+    'certifi>=2025.1.31'
 ]
 
 [project.optional-dependencies]

--- a/src/es_client/__init__.py
+++ b/src/es_client/__init__.py
@@ -3,4 +3,4 @@
 from .builder import Builder
 
 __all__ = ["Builder"]
-__version__ = "8.17.3"
+__version__ = "8.17.4"

--- a/tests/unit/test_helpers_logging_new.py
+++ b/tests/unit/test_helpers_logging_new.py
@@ -131,7 +131,8 @@ class TestLoggerSetup(unittest.TestCase):
                 'logformat': 'default',
                 'blacklist': [],
             }
-            logger = get_logger(log_opts)
+            get_logger(log_opts)
+            logger = logging.getLogger('test_logger_with_logfile')
             logger.info('Test message')
             with open(tmpfile.name, 'r', encoding='utf8') as f:
                 content = f.read()
@@ -140,7 +141,8 @@ class TestLoggerSetup(unittest.TestCase):
     def test_get_logger_without_logfile(self):
         """Test get_logger without a logfile, using stream handlers."""
         log_opts = {'loglevel': 'INFO', 'logformat': 'default', 'blacklist': []}
-        logger = get_logger(log_opts)
+        get_logger(log_opts)
+        logger = logging.getLogger('test_logger_without_logfile')
         stdout = StringIO()
         stderr = StringIO()
         handler_stdout = logging.StreamHandler(stdout)


### PR DESCRIPTION
## Bug Fix

- Fixed a logging configuration bug to only assign a file handler if a log file is specified. Also fixed to ensure configuration goes to the root logger.

## Changes

- Dependency version bumps in this release:
  - `elasticsearch8==8.17.2`
  - `certifi>=2025.3.31`