### PR TITLE
Release prep for v8.19.0

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,24 @@
 Changelog
 =========
 
+[8.19.0] - 2025-09-19
+---------------------
+
+**Announcement**
+
+This will likely be the last minor release in the 8.x series. Patches will be made for dependencies and other code issues.
+
+**Changes**
+
+- Updated ``elasticsearch8`` dependency to ``==8.19.0`` to stay current with the latest Elasticsearch client features and fixes.
+- Updated ``click`` dependency to ``==8.3.0`` to keep up to date.
+- Updated ``certifi`` dependency to ``>=2025.8.3`` to ensure the latest CA certificates are used.
+- Removed ``mix_stderr=True`` from ``clicktest.CliRunner()`` in integration tests to align with current release of Click 8.2+.
+- Updated unit test output parsing to use ``result.stdout`` instead of ``result.output`` to align with the behavior of Click 8.2+.
+- Updated docs/conf.py to reference Click 8.3.x documentation and elasticsearch8 8.19.x documentation.
+- All tests passing.
+
+
 [8.18.2] - 2025-04-21
 ---------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -89,11 +89,11 @@ autodoc_typehints = "description"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.12", None),
-    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.18.0", None),
+    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.19.0", None),
     "elastic-transport": (
         "https://elastic-transport-python.readthedocs.io/en/stable",
         None,
     ),
     "voluptuous": ("http://alecthomas.github.io/voluptuous/docs/_build/html", None),
-    "click": ("https://click.palletsprojects.com/en/8.1.x", None),
+    "click": ("https://click.palletsprojects.com/en/8.3.x", None),
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,13 +29,13 @@ keywords = [
 ]
 dependencies = [
     "cryptography>=44.0.2",
-    "elasticsearch8==8.18.0",
+    "elasticsearch8==8.19.0",
     "ecs-logging==2.2.0",
     "dotmap==1.3.30",
-    "click==8.1.8",
+    "click==8.3.0",
     "pyyaml==6.0.2",
     "voluptuous>=0.14.2",
-    "certifi>=2025.1.31",
+    "certifi>=2025.8.3",
     "tiered-debug>=1.3.0",
 ]
 

--- a/src/es_client/__init__.py
+++ b/src/es_client/__init__.py
@@ -19,7 +19,7 @@ Example Usage:
     # Outputs debug message at level 1, if logging is configured appropriately.
 
 Version:
-    8.18.2
+    8.19.0
 """
 
 from datetime import datetime
@@ -33,7 +33,7 @@ if now.year == FIRST_YEAR:
 else:
     COPYRIGHT_YEARS = f"2025-{now.year}"
 
-__version__ = "8.18.2"
+__version__ = "8.19.0"
 __author__ = "Aaron Mildenstein"
 __copyright__ = f"{COPYRIGHT_YEARS}, {__author__}"
 __license__ = "Apache 2.0"

--- a/tests/integration/test_cli_example.py
+++ b/tests/integration/test_cli_example.py
@@ -37,7 +37,7 @@ class TestCLIExample(TestCase):
             "DEBUG",
             "test-connection",
         ]
-        runner = clicktest.CliRunner(mix_stderr=True)
+        runner = clicktest.CliRunner()
         result = runner.invoke(run, args)
         assert result.exit_code == 0
 

--- a/tests/unit/test_helpers_config.py
+++ b/tests/unit/test_helpers_config.py
@@ -31,9 +31,9 @@ def get_configdict(args, func):
     with ctx:
         runner = CliRunner()
         result = runner.invoke(func, args)
-    click.echo(f'RESULT = {result.output}')
+    click.echo(f'RESULT.stdout = {result.stdout}')
     try:
-        configdict = ast.literal_eval(result.output.splitlines()[-1])
+        configdict = ast.literal_eval(result.stdout.splitlines()[-1])
     except (ValueError, IndexError):
         configdict = {}
     return configdict, result


### PR DESCRIPTION
## Announcement

This will likely be the last minor release in the 8.x series. Patches will be made for dependencies and other code issues.

## Changes

- Updated ``elasticsearch8`` dependency to ``==8.19.0`` to stay current with the latest Elasticsearch client features and fixes.
- Updated ``click`` dependency to ``==8.3.0`` to keep up to date.
- Updated ``certifi`` dependency to ``>=2025.8.3`` to ensure the latest CA certificates are used.
- Removed ``mix_stderr=True`` from ``clicktest.CliRunner()`` in integration tests to align with current release of Click 8.2+.
- Updated unit test output parsing to use ``result.stdout`` instead of ``result.output`` to align with the behavior of Click 8.2+.
- Updated docs/conf.py to reference Click 8.3.x documentation and elasticsearch8 8.19.x documentation.
- All tests passing.