### PR TITLE
Removed references to sphinx_rtd_theme

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,7 +3,14 @@
 Changelog
 =========
 
-[8.19.0] - 2025-09-19
+[8.19.1] - 2025-09-25
+---------------------
+
+**Changes**
+
+To fix the ReadTheDocs builds, I had to remove outdated references to the ``sphinx_rtd_theme`` since I switched to using ``furo``.
+
+[8.19.0] - 2025-09-25
 ---------------------
 
 **Announcement**

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ Attributes:
     author: Author name from es_client.__author__. (str)
     version: Major.minor version (e.g., "1.3"). (str)
     release: Full version (e.g., "1.3.0"). (str)
-    html_theme: Theme for HTML output, defaults to "sphinx_rtd_theme". (str)
+    html_theme: Theme for HTML output, defaults to "furo". (str)
 
 Examples:
     >>> project
@@ -44,7 +44,6 @@ version = ".".join(release.split(".")[:2])
 # -- General configuration ---------------------------------------------------
 
 extensions = [
-    "sphinx_rtd_theme",
     "sphinx.ext.autodoc",
     "sphinx.ext.doctest",
     "sphinx.ext.githubpages",

--- a/src/es_client/__init__.py
+++ b/src/es_client/__init__.py
@@ -19,7 +19,7 @@ Example Usage:
     # Outputs debug message at level 1, if logging is configured appropriately.
 
 Version:
-    8.19.0
+    8.19.1
 """
 
 from datetime import datetime
@@ -33,7 +33,7 @@ if now.year == FIRST_YEAR:
 else:
     COPYRIGHT_YEARS = f"2025-{now.year}"
 
-__version__ = "8.19.0"
+__version__ = "8.19.1"
 __author__ = "Aaron Mildenstein"
 __copyright__ = f"{COPYRIGHT_YEARS}, {__author__}"
 __license__ = "Apache 2.0"


### PR DESCRIPTION
`sphinx_rtd_theme` is no longer used (switched to `furo` instead). ReadTheDocs builds have been failing as a result.