### PR TITLE
Release prep for v8.19.2

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,17 @@
 Changelog
 =========
 
+[8.19.2] - 2025-09-25
+---------------------
+
+**Changes**
+
+- Reverted ``click`` dependency to ``==8.1.8`` to maintain compatibility with Python 3.8 and 3.9. I had inadvertently allowed ``click==8.3.0`` in the last release, which dropped support, which I did not realize until building for es_client v9.0.0. A change was made in 8.2+ that breaks compatibility with 3.8 and 3.9. As many still may be using Python 3.8 and 3.9, I want to maintain compatibility for these users with the 8.x releases.
+- Fixed upstream doc references for Click. Older versions no longer appear to be available, so ``stable`` is what we get now.
+- Removed redundant docstring indices in ``builder.py`` and ``logging.py`` that were generating errors in the document build process.
+
+All tests passing.
+
 [8.19.1] - 2025-09-25
 ---------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -94,5 +94,5 @@ intersphinx_mapping = {
         None,
     ),
     "voluptuous": ("http://alecthomas.github.io/voluptuous/docs/_build/html", None),
-    "click": ("https://click.palletsprojects.com/en/8.3.x", None),
+    "click": ("https://click.palletsprojects.com/en/stable", None),
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "elasticsearch8==8.19.0",
     "ecs-logging==2.2.0",
     "dotmap==1.3.30",
-    "click==8.3.0",
+    "click==8.1.8",
     "pyyaml==6.0.2",
     "voluptuous>=0.14.2",
     "certifi>=2025.8.3",

--- a/src/es_client/__init__.py
+++ b/src/es_client/__init__.py
@@ -19,7 +19,7 @@ Example Usage:
     # Outputs debug message at level 1, if logging is configured appropriately.
 
 Version:
-    8.19.1
+    8.19.2
 """
 
 from datetime import datetime
@@ -33,7 +33,7 @@ if now.year == FIRST_YEAR:
 else:
     COPYRIGHT_YEARS = f"2025-{now.year}"
 
-__version__ = "8.19.1"
+__version__ = "8.19.2"
 __author__ = "Aaron Mildenstein"
 __copyright__ = f"{COPYRIGHT_YEARS}, {__author__}"
 __license__ = "Apache 2.0"

--- a/src/es_client/builder.py
+++ b/src/es_client/builder.py
@@ -122,8 +122,6 @@ class Builder:
         attributes (DotMap): Storage for configuration and settings.
         client (:class:`~elasticsearch8.Elasticsearch`): The Elasticsearch client
             connection.
-        version_min (tuple): Minimum acceptable Elasticsearch version.
-        version_max (tuple): Maximum acceptable Elasticsearch version.
         _secrets (:class:`SecretStore`): Secure storage for sensitive fields.
 
     Raises:

--- a/src/es_client/logging.py
+++ b/src/es_client/logging.py
@@ -519,9 +519,6 @@ class JSONFormatter(logging.Formatter):
     Formats log records as JSON objects with timestamp, log level, logger name,
     function, line number, and message.
 
-    Attributes:
-        WANTED_ATTRS (dict): Mapping of LogRecord attributes to JSON keys.
-
     Example:
         >>> import logging
         >>> record = logging.makeLogRecord({


### PR DESCRIPTION
- Reverted ``click`` dependency to ``==8.1.8`` to maintain compatibility with Python 3.8 and 3.9. I had inadvertently allowed ``click==8.3.0`` in the last release, which dropped support, which I did not realize until building for es_client v9.0.0. A change was made in 8.2+ that breaks compatibility with 3.8 and 3.9. As many still may be using Python 3.8 and 3.9, I want to maintain compatibility for these users with the 8.x releases.
- Fixed upstream doc references for Click. Older versions no longer appear to be available, so ``stable`` is what we get now.
- Removed redundant docstring indices in ``builder.py`` and ``logging.py`` that were generating errors in the document build process.

All tests passing.