### PR TITLE
Release prep for 9.0.1

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,15 @@
 Changelog
 =========
 
+
+[9.0.1] - 2025-10-03
+--------------------
+
+**Changes**
+
+- ``tiered-debug`` dependency bumped to ``1.3.1``. This is a patch to fix test issues that were causing builds from source to fail for package maintainers.
+
+
 [9.0.0] - 2025-09-25
 --------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "pyyaml==6.0.2",
     "voluptuous>=0.14.2",
     "certifi>=2025.8.3",
-    "tiered-debug>=1.3.0",
+    "tiered-debug>=1.3.1",
 ]
 
 [project.optional-dependencies]

--- a/src/es_client/__init__.py
+++ b/src/es_client/__init__.py
@@ -19,7 +19,7 @@ Example Usage:
     # Outputs debug message at level 1, if logging is configured appropriately.
 
 Version:
-    9.0.0
+    9.0.1
 """
 
 from datetime import datetime
@@ -33,7 +33,7 @@ if now.year == FIRST_YEAR:
 else:
     COPYRIGHT_YEARS = f"2025-{now.year}"
 
-__version__ = "9.0.0"
+__version__ = "9.0.1"
 __author__ = "Aaron Mildenstein"
 __copyright__ = f"{COPYRIGHT_YEARS}, {__author__}"
 __license__ = "Apache 2.0"


### PR DESCRIPTION
## Changes

- `tiered-debug` dependency bumped to `1.3.1`. This is a patch to fix test issues that were causing builds from source to fail for package