### PR TITLE
Version bumps for 8.19.3 release

### DIFF
--- a/docs/Changelog.rst
+++ b/docs/Changelog.rst
@@ -3,6 +3,18 @@
 Changelog
 =========
 
+[8.19.3] - 2025-10-06
+---------------------
+
+**Changes**
+
+- Updated ``elasticsearch8`` dependency to ``==8.19.1`` to stay current with the latest Elasticsearch client release.
+- Updated ``certifi`` dependency to ``>=2025.10.5`` to ensure the latest CA certificates are used.
+- Updated ``tiered-debug`` dependency to ``>=1.3.1`` following latest patch release.
+- Updated ``docs/conf.py`` to reference ``elasticsearch8==8.19.1`` documentation.
+
+All tests passing.
+
 [8.19.2] - 2025-09-25
 ---------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,7 @@ autodoc_typehints = "description"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3.12", None),
-    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.19.0", None),
+    "elasticsearch8": ("https://elasticsearch-py.readthedocs.io/en/v8.19.1", None),
     "elastic-transport": (
         "https://elastic-transport-python.readthedocs.io/en/stable",
         None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,14 +29,14 @@ keywords = [
 ]
 dependencies = [
     "cryptography>=44.0.2",
-    "elasticsearch8==8.19.0",
+    "elasticsearch8==8.19.1",
     "ecs-logging==2.2.0",
     "dotmap==1.3.30",
     "click==8.1.8",
     "pyyaml==6.0.2",
     "voluptuous>=0.14.2",
-    "certifi>=2025.8.3",
-    "tiered-debug>=1.3.0",
+    "certifi>=2025.10.5",
+    "tiered-debug>=1.3.1",
 ]
 
 [project.optional-dependencies]

--- a/src/es_client/__init__.py
+++ b/src/es_client/__init__.py
@@ -19,7 +19,7 @@ Example Usage:
     # Outputs debug message at level 1, if logging is configured appropriately.
 
 Version:
-    8.19.2
+    8.19.3
 """
 
 from datetime import datetime
@@ -33,7 +33,7 @@ if now.year == FIRST_YEAR:
 else:
     COPYRIGHT_YEARS = f"2025-{now.year}"
 
-__version__ = "8.19.2"
+__version__ = "8.19.3"
 __author__ = "Aaron Mildenstein"
 __copyright__ = f"{COPYRIGHT_YEARS}, {__author__}"
 __license__ = "Apache 2.0"


### PR DESCRIPTION
- Updated `elasticsearch8` dependency to `==8.19.1` to stay current with the latest Elasticsearch client release.
- Updated `certifi` dependency to `>=2025.10.5` to ensure the latest CA certificates are used.
- Updated `tiered-debug` dependency to `>=1.3.1` following latest patch release.
- Updated `docs/conf.py` to reference `elasticsearch8==8.19.1` documentation.

All tests passing.